### PR TITLE
chore: Specify the working_directory for sys tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,7 @@ jobs:
           name: Remove unencrypted key.
           command: rm .circleci/key.json
           when: always
+    working_directory: /var/error-reporting/
 
   publish_npm:
     docker:


### PR DESCRIPTION
This is needed to fix the problem with the system tests on
CircleCI where the file specified by
GOOGLE_APPLICATION_CREDENTIALS could not be found.