### PR TITLE
chore: release v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/error-reporting",
   "description": "Stackdriver Error Reporting Client Library for Node.js",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {


### PR DESCRIPTION
Draft release notes are at [Draft Release v0.3.0](https://github.com/googleapis/nodejs-error-reporting/releases/tag/untagged-98a8b3dbaad275078fed).