### PR TITLE
chore: workaround for repo-tools EPERM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,12 @@ jobs:
             fi
       - run:
           name: Install modules and dependencies.
-          command: npm install
+          command: |-
+            npm install
+            repo_tools="node_modules/@google-cloud/nodejs-repo-tools/bin/tools"
+            if ! test -x "$repo_tools"; then
+              chmod +x "$repo_tools"
+            fi
       - run:
           name: Run unit tests.
           command: npm test
@@ -117,6 +122,10 @@ jobs:
           name: Install modules and dependencies.
           command: |
             npm install
+            repo_tools="node_modules/@google-cloud/nodejs-repo-tools/bin/tools"
+            if ! test -x "$repo_tools"; then
+              chmod +x "$repo_tools"
+            fi
             npm link
       - run:
           name: Link the module being tested to the samples.
@@ -136,7 +145,12 @@ jobs:
       - run: *remove_package_lock
       - run:
           name: Install modules and dependencies.
-          command: npm install
+          command: |-
+            npm install
+            repo_tools="node_modules/@google-cloud/nodejs-repo-tools/bin/tools"
+            if ! test -x "$repo_tools"; then
+              chmod +x "$repo_tools"
+            fi
       - run:
           name: Build documentation.
           command: npm run docs


### PR DESCRIPTION
Sometimes it just happens, only in CircleCI and never reproduced. Here is a proof that this `chmod` fixes the problem: https://circleci.com/gh/googleapis/nodejs-speech/1376 - let's apply this to all our repos and see if it fails or not.