### PR TITLE
fix: fix the `build` dir missing from releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,5 +210,8 @@ jobs:
           name: Set NPM authentication.
           command: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
       - run:
+          name: Install modules and dependencies.
+          command: npm install
+      - run:
           name: Publish the module to npm.
           command: npm publish


### PR DESCRIPTION
This was caused by the fact that `install` (and hence `compile`)
was not called prior to publishing.  As a result, the build
directory was never created.