### PR TITLE
chore: release v0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/error-reporting",
   "description": "Stackdriver Error Reporting Client Library for Node.js",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {


### PR DESCRIPTION
Draft release notes at [Release Notes v0.3.2](https://github.com/googleapis/nodejs-error-reporting/releases/tag/untagged-279503e52e155db0f9bc).