### PR TITLE
fix: hapi16: properly deal with preResponse errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1815,9 +1815,9 @@
       }
     },
     "@types/boom": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@types/boom/-/boom-4.3.10.tgz",
-      "integrity": "sha512-5iXMLKwCxW0FK0G4XgS5kn0VZQv31DhVAeB36YhxzFpWF4QKa6ZLn4XrziIK2j662p9Azs+lFpFrsuUzC8376g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/boom/-/boom-7.2.0.tgz",
+      "integrity": "sha512-HonbGsHFbskh9zRAzA6tabcw18mCOsSEOL2ibGAuVqk6e7nElcRmWO5L4UfIHpDbWBWw+eZYFdsQ1+MEGgpcVA==",
       "dev": true
     },
     "@types/bunyan": {
@@ -1843,6 +1843,14 @@
       "dev": true,
       "requires": {
         "@types/boom": "4.3.10"
+      },
+      "dependencies": {
+        "@types/boom": {
+          "version": "4.3.10",
+          "resolved": "https://registry.npmjs.org/@types/boom/-/boom-4.3.10.tgz",
+          "integrity": "sha512-5iXMLKwCxW0FK0G4XgS5kn0VZQv31DhVAeB36YhxzFpWF4QKa6ZLn4XrziIK2j662p9Azs+lFpFrsuUzC8376g==",
+          "dev": true
+        }
       }
     },
     "@types/connect": {
@@ -1933,6 +1941,14 @@
         "@types/node": "9.6.4",
         "@types/podium": "1.0.0",
         "@types/shot": "3.4.0"
+      },
+      "dependencies": {
+        "@types/boom": {
+          "version": "4.3.10",
+          "resolved": "https://registry.npmjs.org/@types/boom/-/boom-4.3.10.tgz",
+          "integrity": "sha512-5iXMLKwCxW0FK0G4XgS5kn0VZQv31DhVAeB36YhxzFpWF4QKa6ZLn4XrziIK2j662p9Azs+lFpFrsuUzC8376g==",
+          "dev": true
+        }
       }
     },
     "@types/http-assert": {
@@ -3218,11 +3234,20 @@
       }
     },
     "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
+      "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
+      "dev": true,
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "5.0.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
+          "dev": true
+        }
       }
     },
     "bounce": {
@@ -3329,18 +3354,6 @@
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
-    },
-    "bunyan": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
-      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
-      "dev": true,
-      "requires": {
-        "dtrace-provider": "0.8.6",
-        "moment": "2.22.0",
-        "mv": "2.1.1",
-        "safe-json-stringify": "1.1.0"
-      }
     },
     "bytes": {
       "version": "3.0.0",
@@ -3755,16 +3768,6 @@
           "dev": true,
           "optional": true
         }
-      }
-    },
-    "clone-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
-      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
-      "dev": true,
-      "requires": {
-        "is-regexp": "1.0.0",
-        "is-supported-regexp-flag": "1.0.1"
       }
     },
     "clone-response": {
@@ -4373,39 +4376,6 @@
         }
       }
     },
-    "csv": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/csv/-/csv-1.2.1.tgz",
-      "integrity": "sha1-UjHt/BxxUlEuxFeBB2p6l/9SXAw=",
-      "dev": true,
-      "requires": {
-        "csv-generate": "1.1.2",
-        "csv-parse": "1.3.3",
-        "csv-stringify": "1.1.2",
-        "stream-transform": "0.2.2"
-      }
-    },
-    "csv-generate": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-1.1.2.tgz",
-      "integrity": "sha1-7GsA7a7W5ZrZwgWC9MNk4osUYkA=",
-      "dev": true
-    },
-    "csv-parse": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.3.3.tgz",
-      "integrity": "sha1-0c/YdDwvhJoKuy/VRNtWaV0ZpJA=",
-      "dev": true
-    },
-    "csv-stringify": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
-      "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
-      "dev": true,
-      "requires": {
-        "lodash.get": "4.4.2"
-      }
-    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -4610,12 +4580,6 @@
         "repeating": "2.0.1"
       }
     },
-    "detect-node": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
-      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
-      "dev": true
-    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -4687,16 +4651,6 @@
       "dev": true,
       "requires": {
         "is-obj": "1.0.1"
-      }
-    },
-    "dtrace-provider": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.6.tgz",
-      "integrity": "sha1-QooiOv4DQl0s1tY0f99AxmkDVj0=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.10.0"
       }
     },
     "duplexer3": {
@@ -4920,12 +4874,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
-    },
-    "escape-regexp-component": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
-      "integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI=",
       "dev": true
     },
     "escape-string-regexp": {
@@ -5236,15 +5184,6 @@
       "requires": {
         "d": "1.0.0",
         "es5-ext": "0.10.42"
-      }
-    },
-    "ewma": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ewma/-/ewma-2.0.1.tgz",
-      "integrity": "sha512-MYYK17A76cuuyvkR7MnqLW4iFYPEi5Isl2qb8rXiWpLiwFS9dxW/rncuNnjjgSENuVqZQkIuR4+DChVL4g1lnw==",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
       }
     },
     "execa": {
@@ -6911,12 +6850,6 @@
         }
       }
     },
-    "handle-thing": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
-      "dev": true
-    },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
@@ -7053,6 +6986,16 @@
         "cryptiles": "3.1.2",
         "hoek": "4.2.1",
         "sntp": "2.1.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        }
       }
     },
     "he": {
@@ -7110,18 +7053,6 @@
       "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
       "dev": true
     },
-    "hpack.js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "obuf": "1.1.2",
-        "readable-stream": "2.3.6",
-        "wbuf": "1.7.3"
-      }
-    },
     "htmlparser2": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
@@ -7150,12 +7081,6 @@
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
       "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-      "dev": true
-    },
-    "http-deceiver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
     "http-errors": {
@@ -7614,12 +7539,6 @@
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
-    "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "dev": true
-    },
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -7642,12 +7561,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
       "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
-    },
-    "is-supported-regexp-flag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
-      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -8909,12 +8822,6 @@
         }
       }
     },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -9043,44 +8950,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
-    },
-    "mv": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "mkdirp": "0.5.1",
-        "ncp": "2.0.0",
-        "rimraf": "2.4.5"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "6.0.4"
-          }
-        }
-      }
     },
     "nan": {
       "version": "2.10.0",
@@ -12104,12 +11973,6 @@
         }
       }
     },
-    "obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "dev": true
-    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -12446,12 +12309,6 @@
           "dev": true
         }
       }
-    },
-    "pidusage": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-1.2.0.tgz",
-      "integrity": "sha512-OGo+iSOk44HRJ8q15AyG570UYxcm5u+R99DI8Khu8P3tKGkVu5EZX4ywHglWSTMNNXQ274oeGpYrvFEhDIFGPg==",
-      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -13244,56 +13101,6 @@
         "lowercase-keys": "1.0.1"
       }
     },
-    "restify": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/restify/-/restify-6.4.0.tgz",
-      "integrity": "sha512-p92TXaSuvDWxpmHd7Y5ex1vjFifhNzNZQy99EOPynV/V75fJN5ybHv5mXTD+c1Ffo9fvRv2Yb1FLnfDMpaffPA==",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "bunyan": "1.8.12",
-        "clone-regexp": "1.0.1",
-        "csv": "1.2.1",
-        "dtrace-provider": "0.8.6",
-        "escape-regexp-component": "1.0.2",
-        "ewma": "2.0.1",
-        "formidable": "1.2.1",
-        "http-signature": "1.2.0",
-        "lodash": "4.17.5",
-        "lru-cache": "4.1.2",
-        "mime": "1.6.0",
-        "negotiator": "0.6.1",
-        "once": "1.4.0",
-        "pidusage": "1.2.0",
-        "qs": "6.5.1",
-        "restify-errors": "5.0.0",
-        "semver": "5.5.0",
-        "spdy": "3.4.7",
-        "uuid": "3.2.1",
-        "vasync": "1.6.4",
-        "verror": "1.10.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
-        }
-      }
-    },
-    "restify-errors": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/restify-errors/-/restify-errors-5.0.0.tgz",
-      "integrity": "sha512-+vby9Kxf7qlzvbZSTIEGkIixkeHG+pVCl34dk6eKnL+ua4pCezpdLT/1/eabzPZb65ADrgoc04jeWrrF1E1pvQ==",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "lodash": "4.17.5",
-        "safe-json-stringify": "1.1.0",
-        "verror": "1.10.0"
-      }
-    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -13372,13 +13179,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
-    "safe-json-stringify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.1.0.tgz",
-      "integrity": "sha512-EzBtUaFH9bHYPc69wqjp0efJI/DPNHdFbGE3uIMn4sVbO0zx8vZ8cG4WKxQfOpUOKsQyGBiT2mTqnCw+6nLswA==",
-      "dev": true,
-      "optional": true
-    },
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
@@ -13402,12 +13202,6 @@
         "srcset": "1.0.0",
         "xtend": "4.0.1"
       }
-    },
-    "select-hose": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
-      "dev": true
     },
     "semver": {
       "version": "5.5.0",
@@ -13685,57 +13479,6 @@
         "spdx-ranges": "2.0.0"
       }
     },
-    "spdy": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
-      "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "handle-thing": "1.2.5",
-        "http-deceiver": "1.2.7",
-        "safe-buffer": "5.1.1",
-        "select-hose": "2.0.0",
-        "spdy-transport": "2.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "spdy-transport": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
-      "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "detect-node": "2.0.3",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.2",
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.1",
-        "wbuf": "1.7.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "split-array-stream": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
@@ -13846,12 +13589,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-    },
-    "stream-transform": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.2.2.tgz",
-      "integrity": "sha1-dYZ0h/SVKPi/HYJJllh1PQLfeDg=",
-      "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -14535,32 +14272,6 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
-    "vasync": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/vasync/-/vasync-1.6.4.tgz",
-      "integrity": "sha1-3+k2Fq0OeugBszKp2Iv8XNyOHR8=",
-      "dev": true,
-      "requires": {
-        "verror": "1.6.0"
-      },
-      "dependencies": {
-        "extsprintf": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
-          "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk=",
-          "dev": true
-        },
-        "verror": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
-          "integrity": "sha1-fROyex+swuLakEBetepuW90lLqU=",
-          "dev": true,
-          "requires": {
-            "extsprintf": "1.2.0"
-          }
-        }
-      }
-    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -14621,15 +14332,6 @@
       "dev": true,
       "requires": {
         "vow": "0.4.17"
-      }
-    },
-    "wbuf": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-      "dev": true,
-      "requires": {
-        "minimalistic-assert": "1.0.1"
       }
     },
     "well-known-symbols": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.0.11",
+    "@types/boom": "^7.2.0",
     "@types/express": "^4.11.0",
     "@types/express-serve-static-core": "^4.11.1",
     "@types/extend": "^3.0.0",
@@ -90,6 +91,7 @@
     "@types/tmp": "0.0.33",
     "async": "^2.6.0",
     "body-parser": "^1.15.1",
+    "boom": "^7.2.0",
     "codecov": "^3.0.0",
     "cpy-cli": "^1.0.1",
     "eslint": "^4.9.0",

--- a/src/interfaces/hapi.ts
+++ b/src/interfaces/hapi.ts
@@ -110,15 +110,14 @@ export function makeHapiPlugin(client: RequestHandler, config: Configuration) {
           server.ext(
               'onPreResponse',
               (request: hapi.Request, reply: hapi.ReplyWithContinue) => {
-                if (isObject(request) && isObject(request.response) &&
-                    // TODO: Handle the case when `request.response` is null
-                    request.response!.isBoom) {
+                if (isObject(request) && request.response &&
+                    request.response.isBoom) {
+                  // Cast to {} is necessary, as@types/hapi@16 incorrectly types
+                  // response as 'Response | null' instead of 'Response | Boom |
+                  // null'.
+                  const boom = request.response as {} as Error;
                   const em = hapiErrorHandler(
-                      // TODO: Handle the case when `request.response` is null
-                      // TODO: Handle the type conflict that requires a cast to
-                      // string
-                      new Error(request.response!.message as {} as string),
-                      request, config);
+                      new Error(boom.message), request, config);
                   client.sendError(em);
                 }
 

--- a/test/unit/interfaces/hapi.ts
+++ b/test/unit/interfaces/hapi.ts
@@ -28,6 +28,7 @@ import {RequestHandler} from '../../../src/google-apis/auth-client';
 import {FakeConfiguration as Configuration} from '../../fixtures/configuration';
 import * as http from 'http';
 import * as hapi from 'hapi';
+import * as Boom from 'boom';
 
 const packageJson = require('../../../../package.json');
 
@@ -137,7 +138,7 @@ describe('Hapi interface', () => {
     it('Should call continue when a boom is emitted if reply is an object',
        done => {
          plugin.register(fakeServer, null!, () => {});
-         fakeServer.emit(EVENT, {response: {isBoom: true}}, {
+         fakeServer.emit(EVENT, {response: new Boom('message')}, {
            continue() {
              // The continue function should be called
              done();
@@ -157,7 +158,7 @@ describe('Hapi interface', () => {
            // The continue function should be called
            done();
          };
-         fakeServer.emit(EVENT, {response: {isBoom: true}}, reply);
+         fakeServer.emit(EVENT, {response: new Boom('message')}, reply);
        });
     it('Should call sendError when a boom is received', done => {
       const fakeClient = {
@@ -168,14 +169,14 @@ describe('Hapi interface', () => {
       } as {} as RequestHandler;
       const plugin = hapiInterface(fakeClient, config);
       plugin.register(fakeServer, null!, () => {});
-      fakeServer.emit('onPreResponse', {response: {isBoom: true}});
+      fakeServer.emit('onPreResponse', {response: new Boom('message')});
     });
     it('Should call next when completing a request', done => {
       plugin.register(fakeServer, null!, () => {
         // The next function should be called
         done();
       });
-      fakeServer.emit(EVENT, {response: {isBoom: true}}, {continue() {}});
+      fakeServer.emit(EVENT, {response: new Boom('message')}, {continue() {}});
     });
   });
   describe('Hapi17', () => {


### PR DESCRIPTION
`is.object(o)` returns false when `o` is an Error object. The tests were
never catching this as they were using fake Boom error objects.

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
