### PR TITLE
chore: lock files maintenance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "arrify": "1.0.1",
         "concat-stream": "1.6.2",
         "create-error-class": "3.0.2",
-        "duplexify": "3.5.4",
+        "duplexify": "3.6.0",
         "ent": "2.2.0",
         "extend": "3.0.1",
         "google-auto-auth": "0.10.1",
@@ -1807,7 +1807,7 @@
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/body-parser": {
@@ -1817,7 +1817,7 @@
       "dev": true,
       "requires": {
         "@types/connect": "3.4.32",
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/boom": {
@@ -1833,7 +1833,7 @@
       "dev": true,
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/caseless": {
@@ -1857,7 +1857,7 @@
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/cookies": {
@@ -1869,7 +1869,7 @@
         "@types/connect": "3.4.32",
         "@types/express": "4.11.1",
         "@types/keygrip": "1.0.1",
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/events": {
@@ -1896,7 +1896,7 @@
       "dev": true,
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/extend": {
@@ -1911,7 +1911,7 @@
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/glob": {
@@ -1922,7 +1922,7 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/hapi": {
@@ -1936,7 +1936,7 @@
         "@types/events": "1.2.0",
         "@types/joi": "13.0.8",
         "@types/mimos": "3.0.1",
-        "@types/node": "9.6.8",
+        "@types/node": "9.6.12",
         "@types/podium": "1.0.0",
         "@types/shot": "3.4.0"
       }
@@ -1977,7 +1977,7 @@
         "@types/http-assert": "1.2.2",
         "@types/keygrip": "1.0.1",
         "@types/koa-compose": "3.2.2",
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/koa-compose": {
@@ -2130,7 +2130,7 @@
       "integrity": "sha512-TeiJ7uvv/92ugSqZ0v9l0eNXzutlki0aK+R1K5bfA5SYUil46ITlxLW4iNTCf55P4L5weCmaOdtxGeGWvudwPg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/nock": {
@@ -2139,13 +2139,13 @@
       "integrity": "sha512-S8rJ+SaW82ICX87pZP62UcMifrMfjEdqNzSp+llx4YcvKw6bO650Ye6HwTqER1Dar3S40GIZECQisOrAICDCjA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/node": {
-      "version": "9.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.8.tgz",
-      "integrity": "sha512-0PmgMBskTJa7zDyENW9C7Lunk+I0L2CHYF2RrBRljCmLSMM1fBHIIdvE1IboNNz7N6t+raJIj90YMvUYl2VT1g==",
+      "version": "9.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.12.tgz",
+      "integrity": "sha512-2Z8ziWjJbvV8hHL5YcqCG9ng+/qwUlO1gB4frBD7QI5Wm1Y1iM+AEkGVEv0S5P+aDMwTtAhPJFR4rp1uqagSig==",
       "dev": true
     },
     "@types/once": {
@@ -2180,7 +2180,7 @@
       "requires": {
         "@types/caseless": "0.12.1",
         "@types/form-data": "2.2.1",
-        "@types/node": "9.6.8",
+        "@types/node": "9.6.12",
         "@types/tough-cookie": "2.3.2"
       }
     },
@@ -2191,7 +2191,7 @@
       "dev": true,
       "requires": {
         "@types/bunyan": "1.8.4",
-        "@types/node": "9.6.8",
+        "@types/node": "9.6.12",
         "@types/spdy": "3.4.4"
       }
     },
@@ -2202,7 +2202,7 @@
       "dev": true,
       "requires": {
         "@types/glob": "5.0.35",
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/serve-static": {
@@ -2221,7 +2221,7 @@
       "integrity": "sha1-RZR3xRh9Pr0wNmCrCZ5+ng87ZW8=",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/spdy": {
@@ -2230,7 +2230,7 @@
       "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.12"
       }
     },
     "@types/tmp": {
@@ -2912,7 +2912,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "espower-location-detector": "1.0.0",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -3059,7 +3059,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.10",
         "mkdirp": "0.5.1",
@@ -3083,7 +3083,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -3210,6 +3210,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
         }
       }
     },
@@ -3433,7 +3439,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "deep-equal": "1.0.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -4023,9 +4029,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
       "dev": true
     },
     "core-util-is": {
@@ -4543,9 +4549,9 @@
       "dev": true
     },
     "duplexify": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
-      "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
         "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
@@ -4589,7 +4595,7 @@
       "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "empower-core": "0.6.2"
       }
     },
@@ -4609,7 +4615,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "encodeurl": {
@@ -5026,7 +5032,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "esquery": {
@@ -5174,6 +5180,12 @@
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
           "dev": true
         },
         "safe-buffer": {
@@ -6267,7 +6279,7 @@
         "meow": "4.0.1",
         "pify": "3.0.0",
         "rimraf": "2.6.2",
-        "tslint": "5.9.1",
+        "tslint": "5.10.0",
         "update-notifier": "2.5.0",
         "write-file-atomic": "2.3.0"
       },
@@ -8623,7 +8635,7 @@
         "lodash": "4.17.10",
         "mkdirp": "0.5.1",
         "propagate": "1.0.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "semver": "5.5.0"
       }
     },
@@ -11959,7 +11971,7 @@
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "power-assert-context-traversal": "1.1.1"
       }
     },
@@ -11971,7 +11983,7 @@
       "requires": {
         "acorn": "4.0.13",
         "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
       },
@@ -11990,7 +12002,7 @@
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "estraverse": "4.2.0"
       }
     },
@@ -12000,7 +12012,7 @@
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "power-assert-context-formatter": "1.1.1",
         "power-assert-context-reducer-ast": "1.1.2",
         "power-assert-renderer-assertion": "1.1.1",
@@ -12031,7 +12043,7 @@
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "diff-match-patch": "1.0.0",
         "power-assert-renderer-base": "1.1.1",
         "stringifier": "1.3.0",
@@ -12044,7 +12056,7 @@
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "power-assert-renderer-base": "1.1.1",
         "power-assert-util-string-width": "1.1.1",
         "stringifier": "1.3.0"
@@ -12189,9 +12201,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
       "version": "5.1.1",
@@ -12521,7 +12533,7 @@
         "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "safe-buffer": "5.1.2",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
@@ -12631,7 +12643,7 @@
         "negotiator": "0.6.1",
         "once": "1.4.0",
         "pidusage": "1.2.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "restify-errors": "5.0.0",
         "semver": "5.5.0",
         "spdy": "3.4.7",
@@ -13261,7 +13273,7 @@
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
@@ -13373,7 +13385,7 @@
         "formidable": "1.2.1",
         "methods": "1.1.2",
         "mime": "1.6.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "readable-stream": "2.3.6"
       },
       "dependencies": {
@@ -13588,9 +13600,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
-      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz",
+      "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -158,7 +158,7 @@
             "arrify": "1.0.1",
             "concat-stream": "1.6.2",
             "create-error-class": "3.0.2",
-            "duplexify": "3.5.4",
+            "duplexify": "3.6.0",
             "ent": "2.2.0",
             "extend": "3.0.1",
             "google-auto-auth": "0.10.1",
@@ -1645,7 +1645,7 @@
           "version": "1.3.5",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/body-parser": {
@@ -1653,7 +1653,7 @@
           "bundled": true,
           "requires": {
             "@types/connect": "3.4.32",
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/boom": {
@@ -1665,7 +1665,7 @@
           "bundled": true,
           "requires": {
             "@types/events": "1.2.0",
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/caseless": {
@@ -1683,7 +1683,7 @@
           "version": "3.4.32",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/cookies": {
@@ -1693,7 +1693,7 @@
             "@types/connect": "3.4.32",
             "@types/express": "4.11.1",
             "@types/keygrip": "1.0.1",
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/events": {
@@ -1714,7 +1714,7 @@
           "bundled": true,
           "requires": {
             "@types/events": "1.2.0",
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/extend": {
@@ -1725,7 +1725,7 @@
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/glob": {
@@ -1734,7 +1734,7 @@
           "requires": {
             "@types/events": "1.2.0",
             "@types/minimatch": "3.0.3",
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/hapi": {
@@ -1746,7 +1746,7 @@
             "@types/events": "1.2.0",
             "@types/joi": "13.0.8",
             "@types/mimos": "3.0.1",
-            "@types/node": "9.6.8",
+            "@types/node": "9.6.12",
             "@types/podium": "1.0.0",
             "@types/shot": "3.4.0"
           }
@@ -1777,7 +1777,7 @@
             "@types/http-assert": "1.2.2",
             "@types/keygrip": "1.0.1",
             "@types/koa-compose": "3.2.2",
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/koa-compose": {
@@ -1892,18 +1892,18 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/nock": {
           "version": "9.1.3",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/node": {
-          "version": "9.6.8",
+          "version": "9.6.12",
           "bundled": true
         },
         "@types/once": {
@@ -1928,7 +1928,7 @@
           "requires": {
             "@types/caseless": "0.12.1",
             "@types/form-data": "2.2.1",
-            "@types/node": "9.6.8",
+            "@types/node": "9.6.12",
             "@types/tough-cookie": "2.3.2"
           }
         },
@@ -1937,7 +1937,7 @@
           "bundled": true,
           "requires": {
             "@types/bunyan": "1.8.4",
-            "@types/node": "9.6.8",
+            "@types/node": "9.6.12",
             "@types/spdy": "3.4.4"
           }
         },
@@ -1946,7 +1946,7 @@
           "bundled": true,
           "requires": {
             "@types/glob": "5.0.35",
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/serve-static": {
@@ -1961,14 +1961,14 @@
           "version": "3.4.0",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/spdy": {
           "version": "3.4.4",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.8"
+            "@types/node": "9.6.12"
           }
         },
         "@types/tmp": {
@@ -2518,7 +2518,7 @@
             "babel-generator": "6.26.1",
             "babylon": "6.18.0",
             "call-matcher": "1.0.1",
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "espower-location-detector": "1.0.0",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
@@ -2635,7 +2635,7 @@
           "requires": {
             "babel-core": "6.26.3",
             "babel-runtime": "6.26.0",
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "home-or-tmp": "2.0.0",
             "lodash": "4.17.10",
             "mkdirp": "0.5.1",
@@ -2655,7 +2655,7 @@
           "version": "6.26.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -2758,6 +2758,10 @@
               "requires": {
                 "ms": "2.0.0"
               }
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
             }
           }
         },
@@ -2934,7 +2938,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "deep-equal": "1.0.1",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
@@ -3389,7 +3393,7 @@
           }
         },
         "core-js": {
-          "version": "2.5.5",
+          "version": "2.5.6",
           "bundled": true
         },
         "core-util-is": {
@@ -3792,7 +3796,7 @@
           "bundled": true
         },
         "duplexify": {
-          "version": "3.5.4",
+          "version": "3.6.0",
           "bundled": true,
           "requires": {
             "end-of-stream": "1.4.1",
@@ -3829,7 +3833,7 @@
           "version": "1.2.3",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "empower-core": "0.6.2"
           }
         },
@@ -3845,7 +3849,7 @@
           "bundled": true,
           "requires": {
             "call-signature": "0.0.2",
-            "core-js": "2.5.5"
+            "core-js": "2.5.6"
           }
         },
         "encodeurl": {
@@ -4184,7 +4188,7 @@
           "version": "1.7.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5"
+            "core-js": "2.5.6"
           }
         },
         "esquery": {
@@ -4304,6 +4308,10 @@
             },
             "path-to-regexp": {
               "version": "0.1.7",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
               "bundled": true
             },
             "safe-buffer": {
@@ -4747,7 +4755,7 @@
             "meow": "4.0.1",
             "pify": "3.0.0",
             "rimraf": "2.6.2",
-            "tslint": "5.9.1",
+            "tslint": "5.10.0",
             "update-notifier": "2.5.0",
             "write-file-atomic": "2.3.0"
           },
@@ -6570,7 +6578,7 @@
             "lodash": "4.17.10",
             "mkdirp": "0.5.1",
             "propagate": "1.0.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "semver": "5.5.0"
           }
         },
@@ -9419,7 +9427,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-context-traversal": "1.1.1"
           }
         },
@@ -9429,7 +9437,7 @@
           "requires": {
             "acorn": "4.0.13",
             "acorn-es7-plugin": "1.1.7",
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
           },
@@ -9444,7 +9452,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "estraverse": "4.2.0"
           }
         },
@@ -9452,7 +9460,7 @@
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-context-formatter": "1.1.1",
             "power-assert-context-reducer-ast": "1.1.2",
             "power-assert-renderer-assertion": "1.1.1",
@@ -9477,7 +9485,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "diff-match-patch": "1.0.0",
             "power-assert-renderer-base": "1.1.1",
             "stringifier": "1.3.0",
@@ -9488,7 +9496,7 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-renderer-base": "1.1.1",
             "power-assert-util-string-width": "1.1.1",
             "stringifier": "1.3.0"
@@ -9600,7 +9608,7 @@
           "bundled": true
         },
         "qs": {
-          "version": "6.5.1",
+          "version": "6.5.2",
           "bundled": true
         },
         "query-string": {
@@ -9863,7 +9871,7 @@
             "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
             "performance-now": "2.1.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "safe-buffer": "5.1.2",
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.4",
@@ -9949,7 +9957,7 @@
             "negotiator": "0.6.1",
             "once": "1.4.0",
             "pidusage": "1.2.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "restify-errors": "5.0.0",
             "semver": "5.5.0",
             "spdy": "3.4.7",
@@ -10443,7 +10451,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "traverse": "0.6.6",
             "type-name": "2.0.2"
           }
@@ -10531,7 +10539,7 @@
             "formidable": "1.2.1",
             "methods": "1.1.2",
             "mime": "1.6.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "readable-stream": "2.3.6"
           },
           "dependencies": {
@@ -10692,7 +10700,7 @@
           "bundled": true
         },
         "tslint": {
-          "version": "5.9.1",
+          "version": "5.10.0",
           "bundled": true,
           "requires": {
             "babel-code-frame": "6.26.0",
@@ -11831,7 +11839,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "espower-location-detector": "1.0.0",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -11972,7 +11980,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
@@ -11985,7 +11993,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -12163,7 +12171,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "deep-equal": "1.0.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -12490,9 +12498,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
       "dev": true
     },
     "core-util-is": {
@@ -12636,7 +12644,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "encodeurl": {
@@ -12699,7 +12707,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "estraverse": {


### PR DESCRIPTION
🔨 update lock files to use the latest gRPC (v1.11.3) and make node10 test use pre-built binary