### PR TITLE
chore: update package locks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "log-driver": "1.2.7",
         "methmeth": "1.1.0",
         "modelo": "4.2.3",
-        "request": "2.85.0",
+        "request": "2.86.0",
         "retry-request": "3.3.1",
         "split-array-stream": "1.0.3",
         "stream-events": "1.0.4",
@@ -1794,7 +1794,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -1807,7 +1807,7 @@
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/body-parser": {
@@ -1817,7 +1817,7 @@
       "dev": true,
       "requires": {
         "@types/connect": "3.4.32",
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/boom": {
@@ -1833,7 +1833,7 @@
       "dev": true,
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/caseless": {
@@ -1857,7 +1857,7 @@
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/cookies": {
@@ -1869,7 +1869,7 @@
         "@types/connect": "3.4.32",
         "@types/express": "4.11.1",
         "@types/keygrip": "1.0.1",
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/events": {
@@ -1896,7 +1896,7 @@
       "dev": true,
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/extend": {
@@ -1911,7 +1911,7 @@
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/glob": {
@@ -1922,7 +1922,7 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/hapi": {
@@ -1936,7 +1936,7 @@
         "@types/events": "1.2.0",
         "@types/joi": "13.0.8",
         "@types/mimos": "3.0.1",
-        "@types/node": "9.6.12",
+        "@types/node": "10.1.0",
         "@types/podium": "1.0.0",
         "@types/shot": "3.4.0"
       }
@@ -1948,9 +1948,9 @@
       "dev": true
     },
     "@types/is": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@types/is/-/is-0.0.19.tgz",
-      "integrity": "sha512-OfsDEdzuxfkNXIlAd55eBFCag+I82Ex4jt5s4mOdVS1DHeXaB/zMdgbllTt62qRNCpdypkP36ROj4tUXJTvbZQ==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/is/-/is-0.0.20.tgz",
+      "integrity": "sha512-013vMJ4cpYRm1GavhN8HqSKRWD/txm2BLcy/Qw9hAoSNJwp60ezLH+/QlX3JouGTPJcmxvbDUWGANxjS52jRaw==",
       "dev": true
     },
     "@types/joi": {
@@ -1977,7 +1977,7 @@
         "@types/http-assert": "1.2.2",
         "@types/keygrip": "1.0.1",
         "@types/koa-compose": "3.2.2",
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/koa-compose": {
@@ -2130,7 +2130,7 @@
       "integrity": "sha512-TeiJ7uvv/92ugSqZ0v9l0eNXzutlki0aK+R1K5bfA5SYUil46ITlxLW4iNTCf55P4L5weCmaOdtxGeGWvudwPg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/nock": {
@@ -2139,13 +2139,13 @@
       "integrity": "sha512-S8rJ+SaW82ICX87pZP62UcMifrMfjEdqNzSp+llx4YcvKw6bO650Ye6HwTqER1Dar3S40GIZECQisOrAICDCjA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/node": {
-      "version": "9.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.12.tgz",
-      "integrity": "sha512-2Z8ziWjJbvV8hHL5YcqCG9ng+/qwUlO1gB4frBD7QI5Wm1Y1iM+AEkGVEv0S5P+aDMwTtAhPJFR4rp1uqagSig==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.0.tgz",
+      "integrity": "sha512-sELcX/cJHwRp8kn4hYSvBxKGJ+ubl3MvS8VJQe5gz/sp7CifYxsiCxIJ35wMIYyGVMgfO2AzRa8UcVReAcJRlw==",
       "dev": true
     },
     "@types/once": {
@@ -2180,18 +2180,18 @@
       "requires": {
         "@types/caseless": "0.12.1",
         "@types/form-data": "2.2.1",
-        "@types/node": "9.6.12",
-        "@types/tough-cookie": "2.3.2"
+        "@types/node": "10.1.0",
+        "@types/tough-cookie": "2.3.3"
       }
     },
     "@types/restify": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@types/restify/-/restify-5.0.7.tgz",
-      "integrity": "sha512-0bcMA32Ys6nOQnD4QD6vDvfJg7nx5Dbd+oItNFAad3lwnanm0CqxSZpPQVgVMdD4Vrq/dY7yTaEUwsXOFci2iw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@types/restify/-/restify-5.0.8.tgz",
+      "integrity": "sha512-7nqnFv+M4w0KYajdb0sGy0C5k5OYvPLOPMbacNOM8I2Xm/UQpFnOUluwkkM1FyblVrhgfwHEHVUUZW1VWTXeAQ==",
       "dev": true,
       "requires": {
         "@types/bunyan": "1.8.4",
-        "@types/node": "9.6.12",
+        "@types/node": "10.1.0",
         "@types/spdy": "3.4.4"
       }
     },
@@ -2202,7 +2202,7 @@
       "dev": true,
       "requires": {
         "@types/glob": "5.0.35",
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/serve-static": {
@@ -2221,7 +2221,7 @@
       "integrity": "sha1-RZR3xRh9Pr0wNmCrCZ5+ng87ZW8=",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/spdy": {
@@ -2230,7 +2230,7 @@
       "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.12"
+        "@types/node": "10.1.0"
       }
     },
     "@types/tmp": {
@@ -2240,9 +2240,9 @@
       "dev": true
     },
     "@types/tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha512-vOVmaruQG5EatOU/jM6yU2uCp3Lz6mK1P5Ztu4iJjfM4SVHU9XYktPUQtKlIXuahqXHdEyUarMrBEwg5Cwu+bA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==",
       "dev": true
     },
     "JSV": {
@@ -2609,7 +2609,7 @@
         "lodash.difference": "4.5.0",
         "lodash.flatten": "4.4.0",
         "loud-rejection": "1.6.0",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "matcher": "1.1.0",
         "md5-hex": "2.0.0",
         "meow": "3.7.0",
@@ -2626,7 +2626,7 @@
         "safe-buffer": "5.1.2",
         "semver": "5.5.0",
         "slash": "1.0.0",
-        "source-map-support": "0.5.5",
+        "source-map-support": "0.5.6",
         "stack-utils": "1.0.1",
         "strip-ansi": "4.0.0",
         "strip-bom-buf": "1.0.0",
@@ -2914,7 +2914,7 @@
         "call-matcher": "1.0.1",
         "core-js": "2.5.6",
         "espower-location-detector": "1.0.0",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0"
       }
     },
@@ -3152,11 +3152,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base64url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -3185,9 +3180,9 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
@@ -3195,10 +3190,10 @@
         "debug": "2.6.9",
         "depd": "1.1.2",
         "http-errors": "1.6.3",
-        "iconv-lite": "0.4.19",
+        "iconv-lite": "0.4.23",
         "on-finished": "2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
         "type-is": "1.6.16"
       },
       "dependencies": {
@@ -3210,12 +3205,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-          "dev": true
         }
       }
     },
@@ -3441,7 +3430,7 @@
       "requires": {
         "core-js": "2.5.6",
         "deep-equal": "1.0.1",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0"
       }
     },
@@ -3501,7 +3490,7 @@
         "boom": "7.2.0",
         "bounce": "1.2.0",
         "hoek": "5.0.3",
-        "joi": "13.2.0"
+        "joi": "13.3.0"
       },
       "dependencies": {
         "boom": {
@@ -3622,7 +3611,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.2.3",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3798,13 +3787,13 @@
       "dev": true
     },
     "codecov": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.0.1.tgz",
-      "integrity": "sha512-0TjnXrbvcPzAkRPv/Y5D8aZju/M5adkFxShRyMMgDReB8EV9nF4XMERXs6ajgLA1di9LUFW2tgePDQd2JPWy7g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.0.2.tgz",
+      "integrity": "sha512-9ljtIROIjPIUmMRqO+XuDITDoV8xRrZmA0jcEq6p2hg2+wY9wGmLfreAZGIL72IzUfdEDZaU8+Vjidg1fBQ8GQ==",
       "dev": true,
       "requires": {
         "argv": "0.0.2",
-        "request": "2.85.0",
+        "request": "2.86.0",
         "urlgrey": "0.4.4"
       }
     },
@@ -3925,7 +3914,7 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -4165,7 +4154,7 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
@@ -4466,9 +4455,9 @@
       "dev": true
     },
     "diff-match-patch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
-      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.1.tgz",
+      "integrity": "sha512-A0QEhr4PxGUMEtKxd6X+JLnOTFd3BfIPSDpsc4dMvj+CbSaErDwTpoTo/nFJDMSrjxLW4BiNq+FbNisAAHhWeQ==",
       "dev": true
     },
     "doctrine": {
@@ -4505,9 +4494,9 @@
       "dev": true
     },
     "domhandler": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
         "domelementtype": "1.3.0"
@@ -4575,11 +4564,10 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "base64url": "2.0.0",
         "safe-buffer": "5.1.2"
       }
     },
@@ -4938,9 +4926,9 @@
       "dev": true
     },
     "espower": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/espower/-/espower-2.1.0.tgz",
-      "integrity": "sha1-zh7bPZhwKEH99ZbRy46FvcSujkg=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/espower/-/espower-2.1.1.tgz",
+      "integrity": "sha512-F4TY1qYJB1aUyzB03NsZksZzUQmQoEBaTUjRJGR30GxbkbjKI41NhCyYjrF+bGgWN7x/ZsczYppRpz/0WdI0ug==",
       "dev": true,
       "requires": {
         "array-find": "1.0.0",
@@ -4948,7 +4936,7 @@
         "escodegen": "1.9.1",
         "escope": "3.6.0",
         "espower-location-detector": "1.0.0",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0",
         "source-map": "0.5.7",
         "type-name": "2.0.2",
@@ -5002,7 +4990,7 @@
         "convert-source-map": "1.5.1",
         "empower-assert": "1.1.0",
         "escodegen": "1.9.1",
-        "espower": "2.1.0",
+        "espower": "2.1.1",
         "estraverse": "4.2.0",
         "merge-estraverse-visitors": "1.0.0",
         "multi-stage-sourcemap": "0.2.1",
@@ -5027,9 +5015,9 @@
       "dev": true
     },
     "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
+      "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
       "dev": true,
       "requires": {
         "core-js": "2.5.6"
@@ -5126,7 +5114,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "2.2.4"
       }
     },
     "express": {
@@ -5167,6 +5155,24 @@
         "vary": "1.1.2"
       },
       "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.16"
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -5175,6 +5181,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "dev": true
         },
         "path-to-regexp": {
           "version": "0.1.7",
@@ -5187,6 +5199,44 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
           "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
           "dev": true
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "dev": true
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "dev": true,
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+              "dev": true
+            }
+          }
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -5220,7 +5270,7 @@
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
+        "iconv-lite": "0.4.23",
         "tmp": "0.0.33"
       }
     },
@@ -5308,14 +5358,14 @@
       }
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
-        "randomatic": "1.1.7",
+        "randomatic": "3.0.0",
         "repeat-element": "1.1.2",
         "repeat-string": "1.6.1"
       }
@@ -5359,7 +5409,7 @@
       "dev": true,
       "requires": {
         "commondir": "1.0.1",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "pkg-dir": "2.0.0"
       }
     },
@@ -5489,14 +5539,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
-      "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -5577,7 +5627,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
+          "version": "0.5.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5755,7 +5805,7 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.9.1",
+          "version": "0.10.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5766,7 +5816,7 @@
             "nopt": "4.0.1",
             "npm-packlist": "1.1.10",
             "npmlog": "4.1.2",
-            "rc": "1.2.6",
+            "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
             "tar": "4.4.1"
@@ -5864,12 +5914,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
+            "deep-extend": "0.5.1",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -6169,9 +6219,9 @@
         "axios": "0.18.0",
         "gcp-metadata": "0.6.3",
         "gtoken": "2.3.0",
-        "jws": "3.1.4",
+        "jws": "3.1.5",
         "lodash.isstring": "4.0.1",
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "retry-axios": "0.3.2"
       }
     },
@@ -6183,7 +6233,7 @@
         "async": "2.6.0",
         "gcp-metadata": "0.6.3",
         "google-auth-library": "1.4.0",
-        "request": "2.85.0"
+        "request": "2.86.0"
       }
     },
     "google-p12-pem": {
@@ -6262,7 +6312,7 @@
       "requires": {
         "axios": "0.18.0",
         "google-p12-pem": "1.0.2",
-        "jws": "3.1.4",
+        "jws": "3.1.5",
         "mime": "2.3.1",
         "pify": "3.0.0"
       }
@@ -6456,7 +6506,7 @@
         "catbox-memory": "3.1.2",
         "heavy": "6.1.0",
         "hoek": "5.0.3",
-        "joi": "13.2.0",
+        "joi": "13.3.0",
         "mimos": "4.0.0",
         "podium": "3.1.2",
         "shot": "4.0.5",
@@ -6564,7 +6614,7 @@
       "requires": {
         "boom": "7.2.0",
         "hoek": "5.0.3",
-        "joi": "13.2.0"
+        "joi": "13.3.0"
       },
       "dependencies": {
         "boom": {
@@ -6624,7 +6674,7 @@
       "dev": true,
       "requires": {
         "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
+        "domhandler": "2.4.2",
         "domutils": "1.7.0",
         "entities": "1.1.1",
         "inherits": "2.0.3",
@@ -6704,10 +6754,13 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
     },
     "ignore": {
       "version": "3.3.8",
@@ -7208,9 +7261,9 @@
       "dev": true
     },
     "joi": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.2.0.tgz",
-      "integrity": "sha512-VUzQwyCrmT2lIpxBCYq26dcK9veCQzDh84gQnCtaxCa8ePohX8JZVVsIb+E66kCUUcIvzeIpifa6eZuzqTZ3NA==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.3.0.tgz",
+      "integrity": "sha512-iF6jEYVfBIoYXztYymia1JfuoVbxBNuOcwdbsdoGin9/jjhBLhonKmfTQOvePss8r8v4tU4JOcNmYPHZzKEFag==",
       "dev": true,
       "requires": {
         "hoek": "5.0.3",
@@ -7718,23 +7771,21 @@
       "dev": true
     },
     "jwa": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
       "requires": {
-        "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.9",
+        "ecdsa-sig-formatter": "1.0.10",
         "safe-buffer": "5.1.2"
       }
     },
     "jws": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "base64url": "2.0.0",
-        "jwa": "1.1.5",
+        "jwa": "1.1.6",
         "safe-buffer": "5.1.2"
       }
     },
@@ -8057,9 +8108,9 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
     "lolex": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
+      "integrity": "sha512-e1UtIo1pbrIqEXib/yMjHciyqkng5lc0rrIbytgjmRgDR9+2ceNIAcwOWSgylRjoEP9VdVguCSRwnNmlbnOUwA==",
       "dev": true
     },
     "longest": {
@@ -8094,18 +8145,18 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
     },
     "make-dir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
         "pify": "3.0.0"
@@ -8131,6 +8182,12 @@
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
     },
     "md5-hex": {
       "version": "2.0.0",
@@ -8617,15 +8674,15 @@
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "2.3.2",
+        "lolex": "2.6.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
       }
     },
     "nock": {
-      "version": "9.2.5",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.2.5.tgz",
-      "integrity": "sha512-ciCpyEq72Ws6/yhdayDfd0mAb3eQ7/533xKmFlBQZ5CDwrL0/bddtSicfL7R07oyvPAuegQrR+9ctrlPEp0EjQ==",
+      "version": "9.2.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.2.6.tgz",
+      "integrity": "sha512-loyWSNToPH416mENYcqN/ORNwJvfMs+n1+kk9HS3zO/Eb/ci3TZqoNIWp5oYW9VIFh18jXHxnzYSsrXvA63RYA==",
       "dev": true,
       "requires": {
         "chai": "4.1.2",
@@ -8747,9 +8804,9 @@
       "dev": true
     },
     "nyc": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.7.1.tgz",
-      "integrity": "sha512-EGePURSKUEpS1jWnEKAMhY+GWZzi7JC+f8iBDOATaOsLZW5hM/9eYx2dHGaEXa1ITvMm44CJugMksvP3NwMQMw==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.8.0.tgz",
+      "integrity": "sha512-PUFq1PSsx5OinSk5g5aaZygcDdI3QQT5XUlbR9QRMihtMS6w0Gm8xj4BxmKeeAlpQXC5M2DIhH16Y+KejceivQ==",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -8770,7 +8827,7 @@
         "istanbul-reports": "1.4.0",
         "md5-hex": "1.3.0",
         "merge-source-map": "1.1.0",
-        "micromatch": "2.3.11",
+        "micromatch": "3.1.10",
         "mkdirp": "0.5.1",
         "resolve-from": "2.0.0",
         "rimraf": "2.6.2",
@@ -8820,12 +8877,9 @@
           "dev": true
         },
         "arr-diff": {
-          "version": "2.0.0",
+          "version": "4.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
+          "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
@@ -8838,7 +8892,7 @@
           "dev": true
         },
         "array-unique": {
-          "version": "0.2.1",
+          "version": "0.3.2",
           "bundled": true,
           "dev": true
         },
@@ -8858,7 +8912,7 @@
           "dev": true
         },
         "atob": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true
         },
@@ -8882,7 +8936,7 @@
             "babel-types": "6.26.0",
             "detect-indent": "4.0.0",
             "jsesc": "1.3.0",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "source-map": "0.5.7",
             "trim-right": "1.0.1"
           }
@@ -8900,7 +8954,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -8913,7 +8967,7 @@
             "babel-traverse": "6.26.0",
             "babel-types": "6.26.0",
             "babylon": "6.18.0",
-            "lodash": "4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "babel-traverse": {
@@ -8929,7 +8983,7 @@
             "debug": "2.6.9",
             "globals": "9.18.0",
             "invariant": "2.2.4",
-            "lodash": "4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "babel-types": {
@@ -8939,7 +8993,7 @@
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "to-fast-properties": "1.0.3"
           }
         },
@@ -9023,13 +9077,30 @@
           }
         },
         "braces": {
-          "version": "1.8.5",
+          "version": "2.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
         "builtin-modules": {
@@ -9183,7 +9254,7 @@
           "dev": true
         },
         "core-js": {
-          "version": "2.5.5",
+          "version": "2.5.6",
           "bundled": true,
           "dev": true
         },
@@ -9192,7 +9263,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "which": "1.3.0"
           }
         },
@@ -9319,7 +9390,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "shebang-command": "1.2.0",
                 "which": "1.3.0"
               }
@@ -9327,19 +9398,35 @@
           }
         },
         "expand-brackets": {
-          "version": "0.1.5",
+          "version": "2.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fill-range": "2.2.3"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
         "extend-shallow": {
@@ -9362,28 +9449,88 @@
           }
         },
         "extglob": {
-          "version": "0.3.2",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
-        "filename-regex": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "fill-range": {
-          "version": "2.2.3",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
         "find-cache-dir": {
@@ -9408,14 +9555,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-in": "1.0.2"
-          }
         },
         "foreground-child": {
           "version": "1.5.6",
@@ -9465,23 +9604,6 @@
             "minimatch": "3.0.4",
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
-          }
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-glob": "2.0.1"
           }
         },
         "globals": {
@@ -9670,26 +9792,8 @@
             }
           }
         },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-primitive": "2.0.0"
-          }
-        },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-extglob": {
-          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
@@ -9706,16 +9810,8 @@
           "bundled": true,
           "dev": true
         },
-        "is-glob": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
         "is-number": {
-          "version": "2.1.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -9752,16 +9848,6 @@
             }
           }
         },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "is-stream": {
           "version": "1.1.0",
           "bundled": true,
@@ -9788,12 +9874,9 @@
           "dev": true
         },
         "isobject": {
-          "version": "2.1.0",
+          "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
+          "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
@@ -9934,7 +10017,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
+          "version": "4.17.10",
           "bundled": true,
           "dev": true
         },
@@ -9952,7 +10035,7 @@
           }
         },
         "lru-cache": {
-          "version": "4.1.2",
+          "version": "4.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10010,23 +10093,30 @@
           }
         },
         "micromatch": {
-          "version": "2.3.11",
+          "version": "3.1.10",
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "mimic-fn": {
@@ -10126,14 +10216,6 @@
             "validate-npm-package-license": "3.0.3"
           }
         },
-        "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "1.1.0"
-          }
-        },
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
@@ -10185,15 +10267,6 @@
               "bundled": true,
               "dev": true
             }
-          }
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
           }
         },
         "object.pick": {
@@ -10268,17 +10341,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true
-        },
-        "parse-glob": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
-          }
         },
         "parse-json": {
           "version": "2.2.0",
@@ -10368,52 +10430,10 @@
           "bundled": true,
           "dev": true
         },
-        "preserve": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
         "pseudomap": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
-        },
-        "randomatic": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
         },
         "read-pkg": {
           "version": "1.1.0",
@@ -10450,14 +10470,6 @@
           "bundled": true,
           "dev": true
         },
-        "regex-cache": {
-          "version": "0.4.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-equal-shallow": "0.1.3"
-          }
-        },
         "regex-not": {
           "version": "1.0.2",
           "bundled": true,
@@ -10466,11 +10478,6 @@
             "extend-shallow": "3.0.2",
             "safe-regex": "1.1.0"
           }
-        },
-        "remove-trailing-separator": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
@@ -10701,7 +10708,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "atob": "2.1.0",
+            "atob": "2.1.1",
             "decode-uri-component": "0.2.0",
             "resolve-url": "0.2.1",
             "source-map-url": "0.4.0",
@@ -11357,7 +11364,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "4.0.0",
+            "cliui": "4.1.0",
             "decamelize": "1.2.0",
             "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
@@ -11382,7 +11389,7 @@
               "dev": true
             },
             "cliui": {
-              "version": "4.0.0",
+              "version": "4.1.0",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -11922,7 +11929,7 @@
       "dev": true,
       "requires": {
         "hoek": "5.0.3",
-        "joi": "13.2.0"
+        "joi": "13.3.0"
       },
       "dependencies": {
         "hoek": {
@@ -11984,7 +11991,7 @@
         "acorn": "4.0.13",
         "acorn-es7-plugin": "1.1.7",
         "core-js": "2.5.6",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0"
       },
       "dependencies": {
@@ -12044,7 +12051,7 @@
       "dev": true,
       "requires": {
         "core-js": "2.5.6",
-        "diff-match-patch": "1.0.0",
+        "diff-match-patch": "1.0.1",
         "power-assert-renderer-base": "1.1.1",
         "stringifier": "1.3.0",
         "type-name": "2.0.2"
@@ -12223,43 +12230,27 @@
       "dev": true
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -12270,41 +12261,15 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-          "dev": true,
-          "requires": {
-            "depd": "1.1.1",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.3",
-            "statuses": "1.5.0"
-          }
-        },
-        "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-          "dev": true
-        }
       }
     },
     "rc": {
@@ -12405,9 +12370,9 @@
       }
     },
     "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -12437,7 +12402,7 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
+        "regenerate": "1.4.0",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }
@@ -12513,9 +12478,9 @@
       }
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
+      "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.7.0",
@@ -12535,7 +12500,6 @@
         "performance-now": "2.1.0",
         "qs": "6.5.2",
         "safe-buffer": "5.1.2",
-        "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
         "uuid": "3.2.1"
@@ -12623,9 +12587,9 @@
       }
     },
     "restify": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/restify/-/restify-7.1.1.tgz",
-      "integrity": "sha512-ijHZGOP1UhRhCU4EpI9WbcLXi4v2xe2/3iqPSLcamjZhL9SkZ8TUfpKLRWHZlxWfL2k6Doy10N1gOnvRS9m5qg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/restify/-/restify-7.2.0.tgz",
+      "integrity": "sha512-UXYtu437a5TSim0PgjCiccdUfQS/00VC9gDxqR2/GKaW19OtY3DYDg3HByCAnyO5GiL2y0pBI572wGcxZGP26A==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
@@ -12638,7 +12602,7 @@
         "formidable": "1.2.1",
         "http-signature": "1.2.0",
         "lodash": "4.17.10",
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "mime": "1.6.0",
         "negotiator": "0.6.1",
         "once": "1.4.0",
@@ -12692,7 +12656,7 @@
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.1.tgz",
       "integrity": "sha512-PjAmtWIxjNj4Co/6FRtBl8afRP3CxrrIAnUzb1dzydfROd+6xt7xAebFeskgQgkfFf8NmzrXIoaB3HxmswXyxw==",
       "requires": {
-        "request": "2.85.0",
+        "request": "2.86.0",
         "through2": "2.0.3"
       }
     },
@@ -12756,6 +12720,12 @@
       "integrity": "sha512-EzBtUaFH9bHYPc69wqjp0efJI/DPNHdFbGE3uIMn4sVbO0zx8vZ8cG4WKxQfOpUOKsQyGBiT2mTqnCw+6nLswA==",
       "dev": true,
       "optional": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "samsam": {
       "version": "1.3.0",
@@ -12910,7 +12880,7 @@
       "dev": true,
       "requires": {
         "hoek": "5.0.3",
-        "joi": "13.2.0"
+        "joi": "13.3.0"
       },
       "dependencies": {
         "hoek": {
@@ -12936,7 +12906,7 @@
         "@sinonjs/formatio": "2.0.0",
         "diff": "3.5.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.3.2",
+        "lolex": "2.6.0",
         "nise": "1.3.3",
         "supports-color": "5.4.0",
         "type-detect": "4.0.8"
@@ -12987,9 +12957,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-      "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
       "dev": true,
       "requires": {
         "buffer-from": "1.0.0",
@@ -13178,7 +13148,7 @@
         "cryptiles": "4.1.1",
         "hoek": "5.0.3",
         "iron": "5.0.4",
-        "joi": "13.2.0"
+        "joi": "13.3.0"
       },
       "dependencies": {
         "boom": {
@@ -13277,11 +13247,6 @@
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "4.0.0",
@@ -13594,9 +13559,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+      "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
       "dev": true
     },
     "tslint": {
@@ -13615,8 +13580,8 @@
         "minimatch": "3.0.4",
         "resolve": "1.7.1",
         "semver": "5.5.0",
-        "tslib": "1.9.0",
-        "tsutils": "2.26.2"
+        "tslib": "1.9.1",
+        "tsutils": "2.27.0"
       },
       "dependencies": {
         "resolve": {
@@ -13631,12 +13596,12 @@
       }
     },
     "tsutils": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-      "integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+      "integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.0"
+        "tslib": "1.9.1"
       }
     },
     "tunnel-agent": {
@@ -14190,7 +14155,7 @@
       "requires": {
         "detect-indent": "5.0.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "pify": "3.0.0",
         "sort-keys": "2.0.0",
         "write-file-atomic": "2.3.0"

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -166,7 +166,7 @@
             "log-driver": "1.2.7",
             "methmeth": "1.1.0",
             "modelo": "4.2.3",
-            "request": "2.85.0",
+            "request": "2.86.0",
             "retry-request": "3.3.1",
             "split-array-stream": "1.0.3",
             "stream-events": "1.0.4",
@@ -1645,7 +1645,7 @@
           "version": "1.3.5",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/body-parser": {
@@ -1653,7 +1653,7 @@
           "bundled": true,
           "requires": {
             "@types/connect": "3.4.32",
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/boom": {
@@ -1665,7 +1665,7 @@
           "bundled": true,
           "requires": {
             "@types/events": "1.2.0",
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/caseless": {
@@ -1683,7 +1683,7 @@
           "version": "3.4.32",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/cookies": {
@@ -1693,7 +1693,7 @@
             "@types/connect": "3.4.32",
             "@types/express": "4.11.1",
             "@types/keygrip": "1.0.1",
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/events": {
@@ -1714,7 +1714,7 @@
           "bundled": true,
           "requires": {
             "@types/events": "1.2.0",
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/extend": {
@@ -1725,7 +1725,7 @@
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/glob": {
@@ -1734,7 +1734,7 @@
           "requires": {
             "@types/events": "1.2.0",
             "@types/minimatch": "3.0.3",
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/hapi": {
@@ -1746,7 +1746,7 @@
             "@types/events": "1.2.0",
             "@types/joi": "13.0.8",
             "@types/mimos": "3.0.1",
-            "@types/node": "9.6.12",
+            "@types/node": "10.1.0",
             "@types/podium": "1.0.0",
             "@types/shot": "3.4.0"
           }
@@ -1756,7 +1756,7 @@
           "bundled": true
         },
         "@types/is": {
-          "version": "0.0.19",
+          "version": "0.0.20",
           "bundled": true
         },
         "@types/joi": {
@@ -1777,7 +1777,7 @@
             "@types/http-assert": "1.2.2",
             "@types/keygrip": "1.0.1",
             "@types/koa-compose": "3.2.2",
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/koa-compose": {
@@ -1892,18 +1892,18 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/nock": {
           "version": "9.1.3",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/node": {
-          "version": "9.6.12",
+          "version": "10.1.0",
           "bundled": true
         },
         "@types/once": {
@@ -1928,16 +1928,16 @@
           "requires": {
             "@types/caseless": "0.12.1",
             "@types/form-data": "2.2.1",
-            "@types/node": "9.6.12",
-            "@types/tough-cookie": "2.3.2"
+            "@types/node": "10.1.0",
+            "@types/tough-cookie": "2.3.3"
           }
         },
         "@types/restify": {
-          "version": "5.0.7",
+          "version": "5.0.8",
           "bundled": true,
           "requires": {
             "@types/bunyan": "1.8.4",
-            "@types/node": "9.6.12",
+            "@types/node": "10.1.0",
             "@types/spdy": "3.4.4"
           }
         },
@@ -1946,7 +1946,7 @@
           "bundled": true,
           "requires": {
             "@types/glob": "5.0.35",
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/serve-static": {
@@ -1961,14 +1961,14 @@
           "version": "3.4.0",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/spdy": {
           "version": "3.4.4",
           "bundled": true,
           "requires": {
-            "@types/node": "9.6.12"
+            "@types/node": "10.1.0"
           }
         },
         "@types/tmp": {
@@ -1976,7 +1976,7 @@
           "bundled": true
         },
         "@types/tough-cookie": {
-          "version": "2.3.2",
+          "version": "2.3.3",
           "bundled": true
         },
         "JSV": {
@@ -2264,7 +2264,7 @@
             "lodash.difference": "4.5.0",
             "lodash.flatten": "4.4.0",
             "loud-rejection": "1.6.0",
-            "make-dir": "1.2.0",
+            "make-dir": "1.3.0",
             "matcher": "1.1.0",
             "md5-hex": "2.0.0",
             "meow": "3.7.0",
@@ -2281,7 +2281,7 @@
             "safe-buffer": "5.1.2",
             "semver": "5.5.0",
             "slash": "1.0.0",
-            "source-map-support": "0.5.5",
+            "source-map-support": "0.5.6",
             "stack-utils": "1.0.1",
             "strip-ansi": "4.0.0",
             "strip-bom-buf": "1.0.0",
@@ -2520,7 +2520,7 @@
             "call-matcher": "1.0.1",
             "core-js": "2.5.6",
             "espower-location-detector": "1.0.0",
-            "espurify": "1.7.0",
+            "espurify": "1.8.0",
             "estraverse": "4.2.0"
           }
         },
@@ -2712,10 +2712,6 @@
           "version": "1.0.0",
           "bundled": true
         },
-        "base64url": {
-          "version": "2.0.0",
-          "bundled": true
-        },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
           "bundled": true,
@@ -2737,7 +2733,7 @@
           "bundled": true
         },
         "body-parser": {
-          "version": "1.18.2",
+          "version": "1.18.3",
           "bundled": true,
           "requires": {
             "bytes": "3.0.0",
@@ -2745,10 +2741,10 @@
             "debug": "2.6.9",
             "depd": "1.1.2",
             "http-errors": "1.6.3",
-            "iconv-lite": "0.4.19",
+            "iconv-lite": "0.4.23",
             "on-finished": "2.3.0",
-            "qs": "6.5.1",
-            "raw-body": "2.3.2",
+            "qs": "6.5.2",
+            "raw-body": "2.3.3",
             "type-is": "1.6.16"
           },
           "dependencies": {
@@ -2758,10 +2754,6 @@
               "requires": {
                 "ms": "2.0.0"
               }
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
             }
           }
         },
@@ -2940,7 +2932,7 @@
           "requires": {
             "core-js": "2.5.6",
             "deep-equal": "1.0.1",
-            "espurify": "1.7.0",
+            "espurify": "1.8.0",
             "estraverse": "4.2.0"
           }
         },
@@ -2986,7 +2978,7 @@
             "boom": "7.2.0",
             "bounce": "1.2.0",
             "hoek": "5.0.3",
-            "joi": "13.2.0"
+            "joi": "13.3.0"
           },
           "dependencies": {
             "boom": {
@@ -3081,7 +3073,7 @@
           "requires": {
             "anymatch": "1.3.2",
             "async-each": "1.0.1",
-            "fsevents": "1.2.3",
+            "fsevents": "1.2.4",
             "glob-parent": "2.0.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -3216,11 +3208,11 @@
           "bundled": true
         },
         "codecov": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
             "argv": "0.0.2",
-            "request": "2.85.0",
+            "request": "2.86.0",
             "urlgrey": "0.4.4"
           }
         },
@@ -3315,7 +3307,7 @@
           "requires": {
             "dot-prop": "4.2.0",
             "graceful-fs": "4.1.11",
-            "make-dir": "1.2.0",
+            "make-dir": "1.3.0",
             "unique-string": "1.0.0",
             "write-file-atomic": "2.3.0",
             "xdg-basedir": "3.0.0"
@@ -3501,7 +3493,7 @@
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "shebang-command": "1.2.0",
             "which": "1.3.0"
           }
@@ -3733,7 +3725,7 @@
           "bundled": true
         },
         "diff-match-patch": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true
         },
         "doctrine": {
@@ -3762,7 +3754,7 @@
           "bundled": true
         },
         "domhandler": {
-          "version": "2.4.1",
+          "version": "2.4.2",
           "bundled": true,
           "requires": {
             "domelementtype": "1.3.0"
@@ -3818,10 +3810,9 @@
           }
         },
         "ecdsa-sig-formatter": {
-          "version": "1.0.9",
+          "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "base64url": "2.0.0",
             "safe-buffer": "5.1.2"
           }
         },
@@ -4110,7 +4101,7 @@
           "bundled": true
         },
         "espower": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "bundled": true,
           "requires": {
             "array-find": "1.0.0",
@@ -4118,7 +4109,7 @@
             "escodegen": "1.9.1",
             "escope": "3.6.0",
             "espower-location-detector": "1.0.0",
-            "espurify": "1.7.0",
+            "espurify": "1.8.0",
             "estraverse": "4.2.0",
             "source-map": "0.5.7",
             "type-name": "2.0.2",
@@ -4164,7 +4155,7 @@
             "convert-source-map": "1.5.1",
             "empower-assert": "1.1.0",
             "escodegen": "1.9.1",
-            "espower": "2.1.0",
+            "espower": "2.1.1",
             "estraverse": "4.2.0",
             "merge-estraverse-visitors": "1.0.0",
             "multi-stage-sourcemap": "0.2.1",
@@ -4185,7 +4176,7 @@
           "bundled": true
         },
         "espurify": {
-          "version": "1.7.0",
+          "version": "1.8.0",
           "bundled": true,
           "requires": {
             "core-js": "2.5.6"
@@ -4260,7 +4251,7 @@
           "version": "1.8.2",
           "bundled": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "2.2.4"
           }
         },
         "express": {
@@ -4299,12 +4290,32 @@
             "vary": "1.1.2"
           },
           "dependencies": {
+            "body-parser": {
+              "version": "1.18.2",
+              "bundled": true,
+              "requires": {
+                "bytes": "3.0.0",
+                "content-type": "1.0.4",
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "http-errors": "1.6.3",
+                "iconv-lite": "0.4.19",
+                "on-finished": "2.3.0",
+                "qs": "6.5.1",
+                "raw-body": "2.3.2",
+                "type-is": "1.6.16"
+              }
+            },
             "debug": {
               "version": "2.6.9",
               "bundled": true,
               "requires": {
                 "ms": "2.0.0"
               }
+            },
+            "iconv-lite": {
+              "version": "0.4.19",
+              "bundled": true
             },
             "path-to-regexp": {
               "version": "0.1.7",
@@ -4313,6 +4324,36 @@
             "qs": {
               "version": "6.5.1",
               "bundled": true
+            },
+            "raw-body": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "bytes": "3.0.0",
+                "http-errors": "1.6.2",
+                "iconv-lite": "0.4.19",
+                "unpipe": "1.0.0"
+              },
+              "dependencies": {
+                "depd": {
+                  "version": "1.1.1",
+                  "bundled": true
+                },
+                "http-errors": {
+                  "version": "1.6.2",
+                  "bundled": true,
+                  "requires": {
+                    "depd": "1.1.1",
+                    "inherits": "2.0.3",
+                    "setprototypeof": "1.0.3",
+                    "statuses": "1.4.0"
+                  }
+                },
+                "setprototypeof": {
+                  "version": "1.0.3",
+                  "bundled": true
+                }
+              }
             },
             "safe-buffer": {
               "version": "5.1.1",
@@ -4337,7 +4378,7 @@
           "bundled": true,
           "requires": {
             "chardet": "0.4.2",
-            "iconv-lite": "0.4.19",
+            "iconv-lite": "0.4.23",
             "tmp": "0.0.33"
           }
         },
@@ -4404,12 +4445,12 @@
           }
         },
         "fill-range": {
-          "version": "2.2.3",
+          "version": "2.2.4",
           "bundled": true,
           "requires": {
             "is-number": "2.1.0",
             "isobject": "2.1.0",
-            "randomatic": "1.1.7",
+            "randomatic": "3.0.0",
             "repeat-element": "1.1.2",
             "repeat-string": "1.6.1"
           }
@@ -4445,7 +4486,7 @@
           "bundled": true,
           "requires": {
             "commondir": "1.0.1",
-            "make-dir": "1.2.0",
+            "make-dir": "1.3.0",
             "pkg-dir": "2.0.0"
           }
         },
@@ -4662,9 +4703,9 @@
             "axios": "0.18.0",
             "gcp-metadata": "0.6.3",
             "gtoken": "2.3.0",
-            "jws": "3.1.4",
+            "jws": "3.1.5",
             "lodash.isstring": "4.0.1",
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "retry-axios": "0.3.2"
           }
         },
@@ -4675,7 +4716,7 @@
             "async": "2.6.0",
             "gcp-metadata": "0.6.3",
             "google-auth-library": "1.4.0",
-            "request": "2.85.0"
+            "request": "2.86.0"
           }
         },
         "google-p12-pem": {
@@ -4740,7 +4781,7 @@
           "requires": {
             "axios": "0.18.0",
             "google-p12-pem": "1.0.2",
-            "jws": "3.1.4",
+            "jws": "3.1.5",
             "mime": "2.3.1",
             "pify": "3.0.0"
           }
@@ -4896,7 +4937,7 @@
             "catbox-memory": "3.1.2",
             "heavy": "6.1.0",
             "hoek": "5.0.3",
-            "joi": "13.2.0",
+            "joi": "13.3.0",
             "mimos": "4.0.0",
             "podium": "3.1.2",
             "shot": "4.0.5",
@@ -4981,7 +5022,7 @@
           "requires": {
             "boom": "7.2.0",
             "hoek": "5.0.3",
-            "joi": "13.2.0"
+            "joi": "13.3.0"
           },
           "dependencies": {
             "boom": {
@@ -5028,7 +5069,7 @@
           "bundled": true,
           "requires": {
             "domelementtype": "1.3.0",
-            "domhandler": "2.4.1",
+            "domhandler": "2.4.2",
             "domutils": "1.7.0",
             "entities": "1.1.1",
             "inherits": "2.0.3",
@@ -5095,8 +5136,11 @@
           "bundled": true
         },
         "iconv-lite": {
-          "version": "0.4.19",
-          "bundled": true
+          "version": "0.4.23",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
         },
         "ignore": {
           "version": "3.3.8",
@@ -5468,7 +5512,7 @@
           "bundled": true
         },
         "joi": {
-          "version": "13.2.0",
+          "version": "13.3.0",
           "bundled": true,
           "requires": {
             "hoek": "5.0.3",
@@ -5869,21 +5913,19 @@
           "bundled": true
         },
         "jwa": {
-          "version": "1.1.5",
+          "version": "1.1.6",
           "bundled": true,
           "requires": {
-            "base64url": "2.0.0",
             "buffer-equal-constant-time": "1.0.1",
-            "ecdsa-sig-formatter": "1.0.9",
+            "ecdsa-sig-formatter": "1.0.10",
             "safe-buffer": "5.1.2"
           }
         },
         "jws": {
-          "version": "3.1.4",
+          "version": "3.1.5",
           "bundled": true,
           "requires": {
-            "base64url": "2.0.0",
-            "jwa": "1.1.5",
+            "jwa": "1.1.6",
             "safe-buffer": "5.1.2"
           }
         },
@@ -6126,7 +6168,7 @@
           "bundled": true
         },
         "lolex": {
-          "version": "2.3.2",
+          "version": "2.6.0",
           "bundled": true
         },
         "longest": {
@@ -6153,7 +6195,7 @@
           "bundled": true
         },
         "lru-cache": {
-          "version": "4.1.2",
+          "version": "4.1.3",
           "bundled": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -6161,7 +6203,7 @@
           }
         },
         "make-dir": {
-          "version": "1.2.0",
+          "version": "1.3.0",
           "bundled": true,
           "requires": {
             "pify": "3.0.0"
@@ -6181,6 +6223,10 @@
           "requires": {
             "escape-string-regexp": "1.0.5"
           }
+        },
+        "math-random": {
+          "version": "1.0.1",
+          "bundled": true
         },
         "md5-hex": {
           "version": "2.0.0",
@@ -6562,13 +6608,13 @@
           "requires": {
             "@sinonjs/formatio": "2.0.0",
             "just-extend": "1.1.27",
-            "lolex": "2.3.2",
+            "lolex": "2.6.0",
             "path-to-regexp": "1.7.0",
             "text-encoding": "0.6.4"
           }
         },
         "nock": {
-          "version": "9.2.5",
+          "version": "9.2.6",
           "bundled": true,
           "requires": {
             "chai": "4.1.2",
@@ -6667,7 +6713,7 @@
           "bundled": true
         },
         "nyc": {
-          "version": "11.7.1",
+          "version": "11.8.0",
           "bundled": true,
           "requires": {
             "archy": "1.0.0",
@@ -6688,7 +6734,7 @@
             "istanbul-reports": "1.4.0",
             "md5-hex": "1.3.0",
             "merge-source-map": "1.1.0",
-            "micromatch": "2.3.11",
+            "micromatch": "3.1.10",
             "mkdirp": "0.5.1",
             "resolve-from": "2.0.0",
             "rimraf": "2.6.2",
@@ -6732,11 +6778,8 @@
               "bundled": true
             },
             "arr-diff": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "arr-flatten": "1.1.0"
-              }
+              "version": "4.0.0",
+              "bundled": true
             },
             "arr-flatten": {
               "version": "1.1.0",
@@ -6747,7 +6790,7 @@
               "bundled": true
             },
             "array-unique": {
-              "version": "0.2.1",
+              "version": "0.3.2",
               "bundled": true
             },
             "arrify": {
@@ -6763,7 +6806,7 @@
               "bundled": true
             },
             "atob": {
-              "version": "2.1.0",
+              "version": "2.1.1",
               "bundled": true
             },
             "babel-code-frame": {
@@ -6784,7 +6827,7 @@
                 "babel-types": "6.26.0",
                 "detect-indent": "4.0.0",
                 "jsesc": "1.3.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "source-map": "0.5.7",
                 "trim-right": "1.0.1"
               }
@@ -6800,7 +6843,7 @@
               "version": "6.26.0",
               "bundled": true,
               "requires": {
-                "core-js": "2.5.5",
+                "core-js": "2.5.6",
                 "regenerator-runtime": "0.11.1"
               }
             },
@@ -6812,7 +6855,7 @@
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
                 "babylon": "6.18.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
               }
             },
             "babel-traverse": {
@@ -6827,7 +6870,7 @@
                 "debug": "2.6.9",
                 "globals": "9.18.0",
                 "invariant": "2.2.4",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
               }
             },
             "babel-types": {
@@ -6836,7 +6879,7 @@
               "requires": {
                 "babel-runtime": "6.26.0",
                 "esutils": "2.0.2",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "to-fast-properties": "1.0.3"
               }
             },
@@ -6910,12 +6953,28 @@
               }
             },
             "braces": {
-              "version": "1.8.5",
+              "version": "2.3.2",
               "bundled": true,
               "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
               }
             },
             "builtin-modules": {
@@ -7050,14 +7109,14 @@
               "bundled": true
             },
             "core-js": {
-              "version": "2.5.5",
+              "version": "2.5.6",
               "bundled": true
             },
             "cross-spawn": {
               "version": "4.0.2",
               "bundled": true,
               "requires": {
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "which": "1.3.0"
               }
             },
@@ -7167,7 +7226,7 @@
                   "version": "5.1.0",
                   "bundled": true,
                   "requires": {
-                    "lru-cache": "4.1.2",
+                    "lru-cache": "4.1.3",
                     "shebang-command": "1.2.0",
                     "which": "1.3.0"
                   }
@@ -7175,17 +7234,32 @@
               }
             },
             "expand-brackets": {
-              "version": "0.1.5",
+              "version": "2.1.4",
               "bundled": true,
               "requires": {
-                "is-posix-bracket": "0.1.1"
-              }
-            },
-            "expand-range": {
-              "version": "1.8.2",
-              "bundled": true,
-              "requires": {
-                "fill-range": "2.2.3"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
               }
             },
             "extend-shallow": {
@@ -7206,25 +7280,79 @@
               }
             },
             "extglob": {
-              "version": "0.3.2",
+              "version": "2.0.4",
               "bundled": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "1.0.0",
+                    "is-data-descriptor": "1.0.0",
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
               }
             },
-            "filename-regex": {
-              "version": "2.0.1",
-              "bundled": true
-            },
             "fill-range": {
-              "version": "2.2.3",
+              "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
               }
             },
             "find-cache-dir": {
@@ -7246,13 +7374,6 @@
             "for-in": {
               "version": "1.0.2",
               "bundled": true
-            },
-            "for-own": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "for-in": "1.0.2"
-              }
             },
             "foreground-child": {
               "version": "1.5.6",
@@ -7295,21 +7416,6 @@
                 "minimatch": "3.0.4",
                 "once": "1.4.0",
                 "path-is-absolute": "1.0.1"
-              }
-            },
-            "glob-base": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-glob": "2.0.1"
               }
             },
             "globals": {
@@ -7473,23 +7579,8 @@
                 }
               }
             },
-            "is-dotfile": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "is-equal-shallow": {
-              "version": "0.1.3",
-              "bundled": true,
-              "requires": {
-                "is-primitive": "2.0.0"
-              }
-            },
             "is-extendable": {
               "version": "0.1.1",
-              "bundled": true
-            },
-            "is-extglob": {
-              "version": "1.0.0",
               "bundled": true
             },
             "is-finite": {
@@ -7503,15 +7594,8 @@
               "version": "2.0.0",
               "bundled": true
             },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
             "is-number": {
-              "version": "2.1.0",
+              "version": "3.0.0",
               "bundled": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -7543,14 +7627,6 @@
                 }
               }
             },
-            "is-posix-bracket": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "is-primitive": {
-              "version": "2.0.0",
-              "bundled": true
-            },
             "is-stream": {
               "version": "1.1.0",
               "bundled": true
@@ -7572,11 +7648,8 @@
               "bundled": true
             },
             "isobject": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "isarray": "1.0.0"
-              }
+              "version": "3.0.1",
+              "bundled": true
             },
             "istanbul-lib-coverage": {
               "version": "1.2.0",
@@ -7701,7 +7774,7 @@
               }
             },
             "lodash": {
-              "version": "4.17.5",
+              "version": "4.17.10",
               "bundled": true
             },
             "longest": {
@@ -7716,7 +7789,7 @@
               }
             },
             "lru-cache": {
-              "version": "4.1.2",
+              "version": "4.1.3",
               "bundled": true,
               "requires": {
                 "pseudomap": "1.0.2",
@@ -7766,22 +7839,28 @@
               }
             },
             "micromatch": {
-              "version": "2.3.11",
+              "version": "3.1.10",
               "bundled": true,
               "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
               }
             },
             "mimic-fn": {
@@ -7869,13 +7948,6 @@
                 "validate-npm-package-license": "3.0.3"
               }
             },
-            "normalize-path": {
-              "version": "2.1.1",
-              "bundled": true,
-              "requires": {
-                "remove-trailing-separator": "1.1.0"
-              }
-            },
             "npm-run-path": {
               "version": "2.0.2",
               "bundled": true,
@@ -7920,14 +7992,6 @@
                   "version": "3.0.1",
                   "bundled": true
                 }
-              }
-            },
-            "object.omit": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
               }
             },
             "object.pick": {
@@ -7992,16 +8056,6 @@
             "p-try": {
               "version": "1.0.0",
               "bundled": true
-            },
-            "parse-glob": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-              }
             },
             "parse-json": {
               "version": "2.2.0",
@@ -8078,46 +8132,9 @@
               "version": "0.1.1",
               "bundled": true
             },
-            "preserve": {
-              "version": "0.2.0",
-              "bundled": true
-            },
             "pseudomap": {
               "version": "1.0.2",
               "bundled": true
-            },
-            "randomatic": {
-              "version": "1.1.7",
-              "bundled": true,
-              "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
-              },
-              "dependencies": {
-                "is-number": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "kind-of": "3.2.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "3.2.2",
-                      "bundled": true,
-                      "requires": {
-                        "is-buffer": "1.1.6"
-                      }
-                    }
-                  }
-                },
-                "kind-of": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
             },
             "read-pkg": {
               "version": "1.1.0",
@@ -8150,13 +8167,6 @@
               "version": "0.11.1",
               "bundled": true
             },
-            "regex-cache": {
-              "version": "0.4.4",
-              "bundled": true,
-              "requires": {
-                "is-equal-shallow": "0.1.3"
-              }
-            },
             "regex-not": {
               "version": "1.0.2",
               "bundled": true,
@@ -8164,10 +8174,6 @@
                 "extend-shallow": "3.0.2",
                 "safe-regex": "1.1.0"
               }
-            },
-            "remove-trailing-separator": {
-              "version": "1.1.0",
-              "bundled": true
             },
             "repeat-element": {
               "version": "1.1.2",
@@ -8366,7 +8372,7 @@
               "version": "0.5.1",
               "bundled": true,
               "requires": {
-                "atob": "2.1.0",
+                "atob": "2.1.1",
                 "decode-uri-component": "0.2.0",
                 "resolve-url": "0.2.1",
                 "source-map-url": "0.4.0",
@@ -8946,7 +8952,7 @@
               "version": "11.1.0",
               "bundled": true,
               "requires": {
-                "cliui": "4.0.0",
+                "cliui": "4.1.0",
                 "decamelize": "1.2.0",
                 "find-up": "2.1.0",
                 "get-caller-file": "1.0.2",
@@ -8969,7 +8975,7 @@
                   "bundled": true
                 },
                 "cliui": {
-                  "version": "4.0.0",
+                  "version": "4.1.0",
                   "bundled": true,
                   "requires": {
                     "string-width": "2.1.1",
@@ -9388,7 +9394,7 @@
           "bundled": true,
           "requires": {
             "hoek": "5.0.3",
-            "joi": "13.2.0"
+            "joi": "13.3.0"
           },
           "dependencies": {
             "hoek": {
@@ -9438,7 +9444,7 @@
             "acorn": "4.0.13",
             "acorn-es7-plugin": "1.1.7",
             "core-js": "2.5.6",
-            "espurify": "1.7.0",
+            "espurify": "1.8.0",
             "estraverse": "4.2.0"
           },
           "dependencies": {
@@ -9486,7 +9492,7 @@
           "bundled": true,
           "requires": {
             "core-js": "2.5.6",
-            "diff-match-patch": "1.0.0",
+            "diff-match-patch": "1.0.1",
             "power-assert-renderer-base": "1.1.1",
             "stringifier": "1.3.0",
             "type-name": "2.0.2"
@@ -9625,35 +9631,21 @@
           "bundled": true
         },
         "randomatic": {
-          "version": "1.1.7",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "4.0.0",
+            "kind-of": "6.0.2",
+            "math-random": "1.0.1"
           },
           "dependencies": {
             "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
+              "version": "4.0.0",
+              "bundled": true
             },
             "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "version": "6.0.2",
+              "bundled": true
             }
           }
         },
@@ -9662,33 +9654,13 @@
           "bundled": true
         },
         "raw-body": {
-          "version": "2.3.2",
+          "version": "2.3.3",
           "bundled": true,
           "requires": {
             "bytes": "3.0.0",
-            "http-errors": "1.6.2",
-            "iconv-lite": "0.4.19",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.23",
             "unpipe": "1.0.0"
-          },
-          "dependencies": {
-            "depd": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "http-errors": {
-              "version": "1.6.2",
-              "bundled": true,
-              "requires": {
-                "depd": "1.1.1",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.0.3",
-                "statuses": "1.5.0"
-              }
-            },
-            "setprototypeof": {
-              "version": "1.0.3",
-              "bundled": true
-            }
           }
         },
         "rc": {
@@ -9772,7 +9744,7 @@
           }
         },
         "regenerate": {
-          "version": "1.3.3",
+          "version": "1.4.0",
           "bundled": true
         },
         "regenerator-runtime": {
@@ -9794,7 +9766,7 @@
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "regenerate": "1.3.3",
+            "regenerate": "1.4.0",
             "regjsgen": "0.2.0",
             "regjsparser": "0.1.5"
           }
@@ -9852,7 +9824,7 @@
           }
         },
         "request": {
-          "version": "2.85.0",
+          "version": "2.86.0",
           "bundled": true,
           "requires": {
             "aws-sign2": "0.7.0",
@@ -9873,7 +9845,6 @@
             "performance-now": "2.1.0",
             "qs": "6.5.2",
             "safe-buffer": "5.1.2",
-            "stringstream": "0.0.5",
             "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
             "uuid": "3.2.1"
@@ -9939,7 +9910,7 @@
           }
         },
         "restify": {
-          "version": "7.1.1",
+          "version": "7.2.0",
           "bundled": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -9952,7 +9923,7 @@
             "formidable": "1.2.1",
             "http-signature": "1.2.0",
             "lodash": "4.17.10",
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "mime": "1.6.0",
             "negotiator": "0.6.1",
             "once": "1.4.0",
@@ -9998,7 +9969,7 @@
           "version": "3.3.1",
           "bundled": true,
           "requires": {
-            "request": "2.85.0",
+            "request": "2.86.0",
             "through2": "2.0.3"
           }
         },
@@ -10047,6 +10018,10 @@
           "version": "1.1.0",
           "bundled": true,
           "optional": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
         },
         "samsam": {
           "version": "1.3.0",
@@ -10165,7 +10140,7 @@
           "bundled": true,
           "requires": {
             "hoek": "5.0.3",
-            "joi": "13.2.0"
+            "joi": "13.3.0"
           },
           "dependencies": {
             "hoek": {
@@ -10185,7 +10160,7 @@
             "@sinonjs/formatio": "2.0.0",
             "diff": "3.5.0",
             "lodash.get": "4.4.2",
-            "lolex": "2.3.2",
+            "lolex": "2.6.0",
             "nise": "1.3.3",
             "supports-color": "5.4.0",
             "type-detect": "4.0.8"
@@ -10225,7 +10200,7 @@
           "bundled": true
         },
         "source-map-support": {
-          "version": "0.5.5",
+          "version": "0.5.6",
           "bundled": true,
           "requires": {
             "buffer-from": "1.0.0",
@@ -10378,7 +10353,7 @@
             "cryptiles": "4.1.1",
             "hoek": "5.0.3",
             "iron": "5.0.4",
-            "joi": "13.2.0"
+            "joi": "13.3.0"
           },
           "dependencies": {
             "boom": {
@@ -10455,10 +10430,6 @@
             "traverse": "0.6.6",
             "type-name": "2.0.2"
           }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -10696,7 +10667,7 @@
           "bundled": true
         },
         "tslib": {
-          "version": "1.9.0",
+          "version": "1.9.1",
           "bundled": true
         },
         "tslint": {
@@ -10713,8 +10684,8 @@
             "minimatch": "3.0.4",
             "resolve": "1.7.1",
             "semver": "5.5.0",
-            "tslib": "1.9.0",
-            "tsutils": "2.26.2"
+            "tslib": "1.9.1",
+            "tsutils": "2.27.0"
           },
           "dependencies": {
             "resolve": {
@@ -10727,10 +10698,10 @@
           }
         },
         "tsutils": {
-          "version": "2.26.2",
+          "version": "2.27.0",
           "bundled": true,
           "requires": {
-            "tslib": "1.9.0"
+            "tslib": "1.9.1"
           }
         },
         "tunnel-agent": {
@@ -11159,7 +11130,7 @@
           "requires": {
             "detect-indent": "5.0.0",
             "graceful-fs": "4.1.11",
-            "make-dir": "1.2.0",
+            "make-dir": "1.3.0",
             "pify": "3.0.0",
             "sort-keys": "2.0.0",
             "write-file-atomic": "2.3.0"
@@ -11286,7 +11257,7 @@
             "diff": "3.5.0",
             "formatio": "1.2.0",
             "lodash.get": "4.4.2",
-            "lolex": "2.3.2",
+            "lolex": "2.6.0",
             "nise": "1.3.3",
             "supports-color": "4.5.0",
             "type-detect": "4.0.8"
@@ -11325,7 +11296,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -11556,7 +11527,7 @@
         "lodash.difference": "4.5.0",
         "lodash.flatten": "4.4.0",
         "loud-rejection": "1.6.0",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "matcher": "1.1.0",
         "md5-hex": "2.0.0",
         "meow": "3.7.0",
@@ -11841,7 +11812,7 @@
         "call-matcher": "1.0.1",
         "core-js": "2.5.6",
         "espower-location-detector": "1.0.0",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0"
       }
     },
@@ -12173,7 +12144,7 @@
       "requires": {
         "core-js": "2.5.6",
         "deep-equal": "1.0.1",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0"
       }
     },
@@ -12259,7 +12230,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.2.3",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -12443,7 +12414,7 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -12523,7 +12494,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
@@ -12702,9 +12673,9 @@
       "dev": true
     },
     "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
+      "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
       "dev": true,
       "requires": {
         "core-js": "2.5.6"
@@ -12756,7 +12727,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "2.2.4"
       }
     },
     "express": {
@@ -12843,14 +12814,14 @@
       }
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
-        "randomatic": "1.1.7",
+        "randomatic": "3.0.0",
         "repeat-element": "1.1.2",
         "repeat-string": "1.6.1"
       }
@@ -12876,7 +12847,7 @@
       "dev": true,
       "requires": {
         "commondir": "1.0.1",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "pkg-dir": "2.0.0"
       }
     },
@@ -12963,13 +12934,13 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
-      "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
         "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -13038,7 +13009,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
+          "version": "0.5.1",
           "bundled": true,
           "optional": true
         },
@@ -13194,7 +13165,7 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.9.1",
+          "version": "0.10.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13204,7 +13175,7 @@
             "nopt": "4.0.1",
             "npm-packlist": "1.1.10",
             "npmlog": "4.1.2",
-            "rc": "1.2.6",
+            "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
             "tar": "4.4.1"
@@ -13290,11 +13261,11 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
+            "deep-extend": "0.5.1",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -14180,9 +14151,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
+      "integrity": "sha512-e1UtIo1pbrIqEXib/yMjHciyqkng5lc0rrIbytgjmRgDR9+2ceNIAcwOWSgylRjoEP9VdVguCSRwnNmlbnOUwA==",
       "dev": true
     },
     "longest": {
@@ -14217,18 +14188,18 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
     },
     "make-dir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
         "pify": "3.0.0"
@@ -14256,6 +14227,12 @@
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
     },
     "md5-hex": {
       "version": "2.0.0",
@@ -14531,7 +14508,7 @@
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "2.3.2",
+        "lolex": "2.6.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
       },
@@ -16620,43 +16597,27 @@
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -16787,9 +16748,9 @@
       }
     },
     "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -16813,7 +16774,7 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
+        "regenerate": "1.4.0",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }
@@ -17043,7 +17004,7 @@
       "requires": {
         "diff": "3.5.0",
         "formatio": "1.2.0",
-        "lolex": "2.3.2",
+        "lolex": "2.6.0",
         "native-promise-only": "0.8.1",
         "nise": "1.3.3",
         "path-to-regexp": "1.7.0",
@@ -17695,7 +17656,7 @@
       "requires": {
         "detect-indent": "5.0.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "pify": "3.0.0",
         "sort-keys": "2.0.0",
         "write-file-atomic": "2.3.0"


### PR DESCRIPTION
#118 caused typescript compilation failures in samples tests for some reason. Just verified locally than one more lock files update fixes that.