### PR TITLE
chore: link before install in samples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,8 +154,8 @@ jobs:
           name: Link the module being tested to the samples.
           command: |
             cd samples/
-            npm install
             npm link @google-cloud/error-reporting
+            npm install
             cd ..
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global


### PR DESCRIPTION
To allow linting samples for versions that are not released yet, we first need to `npm link`, then `npm install` in samples.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
