### PR TITLE
chore: fix samples linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,21 @@ jobs:
     steps:
       - checkout
       - run: *remove_package_lock
-      - run: npm install
-      - run: cd samples && npm install && cd ../
-      - run: npm run lint
+      - run: *npm_install_and_link
+      - run: &samples_npm_install_and_link
+          name: Link the module being tested to the samples.
+          command: |
+            cd samples/
+            npm link @google-cloud/error-reporting
+            npm install
+            cd ..
+          environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
+      - run: 
+          name: Run linting.
+          command: npm run lint
+          environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
   docs:
     docker:
       - image: 'node:8'
@@ -150,15 +162,7 @@ jobs:
                 -out .circleci/key.json \
                 -k "${SYSTEM_TESTS_ENCRYPTION_KEY}"
       - run: *npm_install_and_link
-      - run: &samples_npm_install_and_link
-          name: Link the module being tested to the samples.
-          command: |
-            cd samples/
-            npm link @google-cloud/error-reporting
-            npm install
-            cd ..
-          environment:
-            NPM_CONFIG_PREFIX: /home/node/.npm-global
+      - run: *samples_npm_install_and_link
       - run:
           name: Run sample tests.
           command: npm run samples-test


### PR DESCRIPTION
So basically, to make it work with versions not released yet (like 0.5.0 in this case), we need to run `npm link` both in lint and in samples test. Sad but true, don't know how to make it easier.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
