### PR TITLE
chore(release): bump version to 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/error-reporting",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/error-reporting",
   "description": "Stackdriver Error Reporting Client Library for Node.js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {


### PR DESCRIPTION
[release notes](https://github.com/googleapis/nodejs-error-reporting/releases/edit/untagged-1fac027688319935e795#)
---
This release picks up an updated dependency for [`@google-cloud/common`](https://npmjs.com/@google-cloud/common) to fix typescript compile issue for some users (e.g. #155).

# Commits
* 002cf33 chore(release): bump version to 0.5.1
* 8053a41 fix: upgrade to @google-cloud/common@0.20.3 (#158)
* cc95f61 chore(deps): lock file maintenance (#157)
* 924470a chore(deps): lock file maintenance (#156)
* a631877 chore(deps): update dependency nyc to v12 (#152)
* 0aa1e97 chore(deps): update dependency sinon to v6 (#153)
* b017ad6 fix(deps): update dependency yargs to v12 (#154)
* b65a182 chore(deps): update dependency sinon to v5.1.1 (#151)