### PR TITLE
chore: fix `lodash.has` usage

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -29,7 +29,7 @@ const env = process.env;
 // TypeScript users of the error reporting library would
 // need to install @types/console-log-level to compile their
 // code.  As a result, the interface is explicitly specified instead.
-export type LogLevel = "error" | "trace" | "debug" | "info" | "warn" | "fatal" | undefined;
+export type LogLevel = 'error'|'trace'|'debug'|'info'|'warn'|'fatal'|undefined;
 export interface Logger {
   error(...args: Array<{}>): void;
   trace(...args: Array<{}>): void;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,7 +15,7 @@
  */
 
 import * as is from 'is';
-import {has} from 'lodash';
+import has = require('lodash.has');
 
 const isObject = is.object;
 const isBoolean = is.boolean;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,7 +15,7 @@
  */
 
 import * as is from 'is';
-import {has} from 'lodash';
+import has = require('lodash.has');
 import consoleLogLevel = require('console-log-level');
 
 const packageJson = require('../../package.json');

--- a/src/populate-error-message.ts
+++ b/src/populate-error-message.ts
@@ -15,7 +15,7 @@
  */
 
 import * as is from 'is';
-import {has} from 'lodash';
+import has = require('lodash.has');
 
 const isObject = is.object;
 import {buildStackTrace} from './build-stack-trace';

--- a/src/request-extractors/hapi.ts
+++ b/src/request-extractors/hapi.ts
@@ -16,7 +16,7 @@
 
 import * as boom from 'boom';
 import * as is from 'is';
-import {has} from 'lodash';
+import has = require('lodash.has');
 
 const isObject = is.object;
 const isFunction = is.function;

--- a/src/request-extractors/manual.ts
+++ b/src/request-extractors/manual.ts
@@ -15,7 +15,7 @@
  */
 
 import * as is from 'is';
-import {has} from 'lodash';
+import has = require('lodash.has');
 
 const isObject = is.object;
 const isArray = is.array;

--- a/test/test-servers/express_scaffold_server.ts
+++ b/test/test-servers/express_scaffold_server.ts
@@ -16,7 +16,7 @@
 
 const WARNING_HEADER = '\n!! -WARNING-';
 const EXCLAMATION_LN = '\n!!';
-import {has} from 'lodash';
+import has = require('lodash.has');
 import * as express from 'express';
 const app = express();
 const errorHandler = require('../../src/index.js')({

--- a/test/unit/interfaces/hapi.ts
+++ b/test/unit/interfaces/hapi.ts
@@ -15,7 +15,7 @@
  */
 
 import * as is from 'is';
-import {has} from 'lodash';
+import has = require('lodash.has');
 
 const isFunction = (is as {} as {fn: Function}).fn;
 const isObject = is.object;


### PR DESCRIPTION
The previous use of `lodash.has` caused the installation tests
to fail.
