### PR TITLE
chore: do not target `es5`

### DIFF
--- a/system-test/test-install.ts
+++ b/system-test/test-install.ts
@@ -154,7 +154,7 @@ app.use(function *(this: any): IterableIterator<any> {
 });
 `,
     description: 'uses koa',
-    dependencies: ['koa'],
+    dependencies: ['koa@1.x.x'],
     devDependencies: ['@types/koa']
   },
   {
@@ -220,7 +220,7 @@ new ErrorReporting({
     code: `const express = require('express');
 
 const ErrorReporting = require('@google-cloud/error-reporting').ErrorReporting;
-const errors = ErrorReporting();
+const errors = new ErrorReporting();
 
 const app = express();
 
@@ -315,7 +315,7 @@ app.use(function *(){
 });
 `,
     description: 'uses koa',
-    dependencies: ['koa'],
+    dependencies: ['koa@1.x.x'],
     devDependencies: []
   },
   {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build",
-    "target": "es5"
+    "outDir": "build"
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
Targeting `es5` caused the koa plugin, which is a generator
function, to be transpiled into a regular function.  As a result,
Koa@1 would refuse to use the plugin.