### PR TITLE
chore: fix sys test failure caused by a type error

### DIFF
--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -522,7 +522,7 @@ describe('error-reporting', () => {
       assert.strictEqual(matchedErrors.length, 1);
       const errItem = matchedErrors[0];
       assert.ok(errItem);
-      assert.strictEqual(errItem.count, 1);
+      assert.strictEqual(errItem.count, '1');
       const rep = errItem.representative;
       assert.ok(rep);
       // Ensure the stack trace in the message does not contain any frames


### PR DESCRIPTION
The failed tests can be viewed at [https://circleci.com/gh/googleapis/nodejs-error-reporting/4582?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link](https://circleci.com/gh/googleapis/nodejs-error-reporting/4582?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

In particular, the `count` property on a error is of type `string` but was compared against a number.