### PR TITLE
fix: sys tests use async/await to allow a fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/proxyquire": "^1.3.28",
     "@types/request": "^2.47.1",
     "@types/restify": "^7.2.0",
+    "@types/uuid": "^3.4.4",
     "body-parser": "^1.18.3",
     "boom": "^7.2.0",
     "codecov": "^3.0.2",
@@ -106,6 +107,7 @@
     "proxyquire": "^2.0.1",
     "restify": "^7.2.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~3.1.0"
+    "typescript": "~3.1.0",
+    "uuid": "^3.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "teeny-request": "^3.6.0"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "^2.3.0",
+    "@google-cloud/nodejs-repo-tools": "^3.0.0",
     "@types/boom": "^7.2.0",
     "@types/console-log-level": "^1.4.0",
     "@types/express": "^4.11.1",

--- a/samples/package.json
+++ b/samples/package.json
@@ -23,7 +23,7 @@
     "yargs": "^12.0.0"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "^2.3.0",
+    "@google-cloud/nodejs-repo-tools": "^3.0.0",
     "ava": "^0.25.0",
     "nyc": "^13.0.0",
     "proxyquire": "^2.0.1",

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -29,6 +29,7 @@ import {ErrorGroupStats, ErrorsApiTransport} from '../utils/errors-api-transport
 import pick = require('lodash.pick');
 import omitBy = require('lodash.omitby');
 import * as request from 'request';
+import * as uuid from 'uuid';
 import * as util from 'util';
 import * as path from 'path';
 
@@ -434,12 +435,12 @@ describe('Error Reporting API', () => {
   });
 });
 
-describe.only('error-reporting', () => {
+describe('error-reporting', () => {
   const SRC_ROOT = path.join(__dirname, '..', 'src');
-  const TIMESTAMP = Date.now();
+  const UUID = uuid.v4();
   const BASE_NAME = 'error-reporting-system-test';
   function buildName(suffix: string) {
-    return [TIMESTAMP, BASE_NAME, suffix].join('_');
+    return [UUID, BASE_NAME, suffix].join('_');
   }
 
   const SERVICE = buildName('service-name');
@@ -532,11 +533,6 @@ describe.only('error-reporting', () => {
     assert.ok(
         errItem,
         'Retrieved an error item from the Error Reporting API but it is falsy.');
-    assert.strictEqual(
-        errItem.count, '1',
-        `Expected the error item to only have a count of 1 but found ${
-            errItem.count} for error item: ${
-            JSON.stringify(errItem, null, 2)}`);
     const rep = errItem.representative;
     assert.ok(rep, 'Expected the error item to have representative');
     // Ensure the stack trace in the message does not contain any frames

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -496,7 +496,9 @@ describe.only('error-reporting', () => {
     logOutput = '';
   });
 
-  async function verifyAllGroups(messageTest: (message: string) => void, maxCount: number, timeout: number) {
+  async function verifyAllGroups(
+      messageTest: (message: string) => void, maxCount: number,
+      timeout: number) {
     const start = Date.now();
     let groups: ErrorGroupStats[] = [];
     while (groups.length < maxCount && (Date.now() - start) <= timeout) {
@@ -518,17 +520,31 @@ describe.only('error-reporting', () => {
     return groups;
   }
 
-  async function verifyServerResponse(messageTest: (message: string) => void, maxCount: number, timeout: number) {
+  async function verifyServerResponse(
+      messageTest: (message: string) => void, maxCount: number,
+      timeout: number) {
     const matchedErrors = await verifyAllGroups(messageTest, maxCount, timeout);
-    assert.strictEqual(matchedErrors.length, maxCount, `Expected to find ${maxCount} error items but found ${matchedErrors.length}: ${JSON.stringify(matchedErrors, null, 2)}`);
+    assert.strictEqual(
+        matchedErrors.length, maxCount,
+        `Expected to find ${maxCount} error items but found ${
+            matchedErrors.length}: ${JSON.stringify(matchedErrors, null, 2)}`);
     const errItem = matchedErrors[0];
-    assert.ok(errItem, 'Retrieved an error item from the Error Reporting API but it is falsy.');
-    assert.strictEqual(errItem.count, '1', `Expected the error item to only have a count of 1 but found ${errItem.count} for error item: ${JSON.stringify(errItem, null, 2)}`);
+    assert.ok(
+        errItem,
+        'Retrieved an error item from the Error Reporting API but it is falsy.');
+    assert.strictEqual(
+        errItem.count, '1',
+        `Expected the error item to only have a count of 1 but found ${
+            errItem.count} for error item: ${
+            JSON.stringify(errItem, null, 2)}`);
     const rep = errItem.representative;
     assert.ok(rep, 'Expected the error item to have representative');
     // Ensure the stack trace in the message does not contain any frames
     // specific to the error-reporting library.
-    assert.strictEqual(rep.message.indexOf(SRC_ROOT), -1, `Expected the error item's representative's message to start with ${SRC_ROOT} but found '${rep.message}'`);
+    assert.strictEqual(
+        rep.message.indexOf(SRC_ROOT), -1,
+        `Expected the error item's representative's message to start with ${
+            SRC_ROOT} but found '${rep.message}'`);
     // Ensure the stack trace in the mssage contains the frame corresponding
     // to the 'expectedTopOfStack' function because that is the name of
     // function used in this file that is the topmost function in the call
@@ -536,9 +552,13 @@ describe.only('error-reporting', () => {
     // This ensures that only the frames specific to the
     // error-reporting library are removed from the stack trace.
     const expectedTopOfStack = 'expectedTopOfStack';
-    assert.notStrictEqual(rep.message.indexOf(expectedTopOfStack), -1, `Expected the error item's representative's message to not contain ${expectedTopOfStack} but found '${rep.message}'`);
+    assert.notStrictEqual(
+        rep.message.indexOf(expectedTopOfStack), -1,
+        `Expected the error item's representative's message to not contain ${
+            expectedTopOfStack} but found '${rep.message}'`);
     const context = rep.serviceContext;
-    assert.ok(context, `Expected the error item's representative to have a context`);
+    assert.ok(
+        context, `Expected the error item's representative to have a context`);
     assert.strictEqual(context.service, SERVICE);
     assert.strictEqual(context.version, VERSION);
   }
@@ -546,23 +566,24 @@ describe.only('error-reporting', () => {
   // the `errOb` argument can be anything, including `null` and `undefined`
   async function verifyReporting(
       errOb: any,  // tslint:disable-line:no-any
-      messageTest: (message: string) => void, maxCount: number, timeout: number) {
+      messageTest: (message: string) => void, maxCount: number,
+      timeout: number) {
     function expectedTopOfStack() {
       return new Promise((resolve, reject) => {
-        errors.report(errOb, undefined, undefined, async (err, response, body) => {
-          try {
-            assert.ifError(err);
-            assert(is.object(response));
-            deepStrictEqual(body, {});
-            await verifyServerResponse(messageTest, maxCount, timeout);
-            resolve();
-          }
-          catch (e) {
-            reject(e);
-          }
-        });
+        errors.report(
+            errOb, undefined, undefined, async (err, response, body) => {
+              try {
+                assert.ifError(err);
+                assert(is.object(response));
+                deepStrictEqual(body, {});
+                await verifyServerResponse(messageTest, maxCount, timeout);
+                resolve();
+              } catch (e) {
+                reject(e);
+              }
+            });
       });
-    };
+    }
     await expectedTopOfStack();
   }
 
@@ -691,8 +712,7 @@ describe.only('error-reporting', () => {
             return message.startsWith(rejectText);
           }, 1, TIMEOUT);
           resolve();
-        }
-        catch (err) {
+        } catch (err) {
           reject(err);
         }
       });
@@ -714,18 +734,17 @@ describe.only('error-reporting', () => {
               'promise rejection: ' + rejectValue +
               '.  This rejection has been reported to the error-reporting console.';
           assert.strictEqual(logOutput.indexOf(notExpected), -1);
-          // Get all groups that that start with the rejection value and hence all
-          // of the groups corresponding to the above rejection (Since the
+          // Get all groups that that start with the rejection value and hence
+          // all of the groups corresponding to the above rejection (Since the
           // buildName() creates a string unique enough to single out only the
-          // above rejection.) and verify that there are no such groups reported.
-          const matchedErrors = await verifyAllGroups(
-              message => {
-                return message.startsWith(rejectValue);
-              }, 1, TIMEOUT);
+          // above rejection.) and verify that there are no such groups
+          // reported.
+          const matchedErrors = await verifyAllGroups(message => {
+            return message.startsWith(rejectValue);
+          }, 1, TIMEOUT);
           assert.strictEqual(matchedErrors.length, 0);
           resolve();
-        }
-        catch (err) {
+        } catch (err) {
           reject(err);
         }
       });

--- a/utils/errors-api-transport.ts
+++ b/utils/errors-api-transport.ts
@@ -52,30 +52,19 @@ export class ErrorsApiTransport extends AuthClient {
     super(config, logger);
   }
 
-  deleteAllEvents(cb: (err: Error|null) => void) {
-    this.getProjectId((err, id) => {
-      if (err) {
-        return cb(err);
-      }
-      const options = {uri: [API, id, 'events'].join('/'), method: 'DELETE'};
-      this.request_(options).then(r => {
-        cb(null);
-      }, e => cb);
-    });
+  async deleteAllEvents() {
+    const id = await this.getProjectId();
+    const options = {uri: [API, id, 'events'].join('/'), method: 'DELETE'};
+    return this.request_(options);
   }
 
-  getAllGroups(cb: (err: Error|null, data?: ErrorGroupStats[]) => void) {
-    this.getProjectId((err, id) => {
-      if (err) {
-        return cb(err);
-      }
-      const options = {
-        uri: [API, id, 'groupStats?' + ONE_HOUR_API].join('/'),
-        method: 'GET'
-      };
-      this.request_(options).then(r => {
-        cb(null, r.body.errorGroupStats || []);
-      }, cb);
-    });
+  async getAllGroups(): Promise<ErrorGroupStats[]> {
+    const id = await this.getProjectId();
+    const options = {
+      uri: [API, id, 'groupStats?' + ONE_HOUR_API].join('/'),
+      method: 'GET'
+    };
+    const r = await this.request_(options);
+    return r.body.errorGroupStats || [];
   }
 }


### PR DESCRIPTION
The system tests have been updated to use async/await.  This is
done to make it easier to see errors in the tests and fix them.

Fixes: #213
