### PR TITLE
chore: address system test flakiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "boom": "^7.2.0",
     "codecov": "^3.0.2",
     "cpy-cli": "^2.0.0",
+    "delay": "^4.1.0",
     "eslint": "^5.0.0",
     "eslint-config-prettier": "^3.0.0",
     "eslint-plugin-node": "^8.0.0",

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from 'assert';
+import delay from 'delay';
 import * as is from 'is';
 import * as nock from 'nock';
 
@@ -138,12 +139,6 @@ if (!shouldRun()) {
   console.log('Skipping error-reporting system tests');
   // eslint-disable-next-line no-process-exit
   process.exit(1);
-}
-
-function sleep(timeout: number) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, timeout);
-  });
 }
 
 describe('Request/Response lifecycle mocking', () => {
@@ -517,7 +512,7 @@ describe('error-reporting', () => {
             messageTest(errItem.representative.message));
       });
       groups = groups.concat(filteredGroups);
-      await sleep(1000);
+      await delay(5000);
     }
 
     return groups;

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -688,7 +688,7 @@ describe('error-reporting', () => {
   it('Should report unhandledRejections if enabled', async function(this) {
     this.timeout(TIMEOUT * 4);
     reinitialize({reportUnhandledRejections: true});
-    const rejectValue = buildName('promise-rejection');
+    const rejectValue = buildName('report-promise-rejection');
     function expectedTopOfStack() {
       // An Error is used for the rejection value so that it's stack
       // contains the stack trace at the point the rejection occured and is
@@ -720,7 +720,7 @@ describe('error-reporting', () => {
   it('Should not report unhandledRejections if disabled', async function(this) {
     this.timeout(TIMEOUT * 2);
     reinitialize({reportUnhandledRejections: false});
-    const rejectValue = buildName('promise-rejection');
+    const rejectValue = buildName('do-not-report-promise-rejection');
     const canaryValue = buildName('canary-value');
     function expectedTopOfStack() {
       Promise.reject(rejectValue);

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -674,7 +674,7 @@ describe('error-reporting', () => {
      });
 
   it('Should report unhandledRejections if enabled', async function(this) {
-    this.timeout(TIMEOUT * 4);
+    this.timeout(TIMEOUT * 5);
     reinitialize({reportUnhandledRejections: true});
     const rejectValue = buildName('report-promise-rejection');
     function expectedTopOfStack() {

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -461,7 +461,6 @@ describe('error-reporting', () => {
       logOutput += text;
     };
     reinitialize();
-    await transport.deleteAllEvents();
   });
 
   function reinitialize(extraConfig?: {}) {
@@ -482,12 +481,6 @@ describe('error-reporting', () => {
     const configuration = new Configuration(initConfiguration, logger);
     transport = new ErrorsApiTransport(configuration, logger);
   }
-
-  after(async () => {
-    if (transport) {
-      await transport.deleteAllEvents();
-    }
-  });
 
   afterEach(() => {
     logOutput = '';

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -445,6 +445,7 @@ describe('error-reporting', () => {
 
   const SERVICE = buildName('service-name');
   const VERSION = buildName('service-version');
+  const PAGE_SIZE = 100;
 
   let errors: ErrorReporting;
   let transport: ErrorsApiTransport;
@@ -503,7 +504,8 @@ describe('error-reporting', () => {
     const start = Date.now();
     let groups: ErrorGroupStats[] = [];
     while (groups.length < maxCount && (Date.now() - start) <= timeout) {
-      const allGroups = await transport.getAllGroups();
+      const allGroups =
+          await transport.getAllGroups(SERVICE, VERSION, PAGE_SIZE);
       assert.ok(allGroups, 'Failed to get groups from the Error Reporting API');
 
       const filteredGroups = allGroups!.filter(errItem => {

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -34,7 +34,7 @@ import * as util from 'util';
 import * as path from 'path';
 
 const ERR_TOKEN = '_@google_STACKDRIVER_INTEGRATION_TEST_ERROR__';
-const TIMEOUT = 120000;
+const TIMEOUT = 10 * 60 * 1000;
 
 const envKeys = [
   'GOOGLE_APPLICATION_CREDENTIALS',

--- a/utils/errors-api-transport.ts
+++ b/utils/errors-api-transport.ts
@@ -58,10 +58,16 @@ export class ErrorsApiTransport extends AuthClient {
     return this.request_(options);
   }
 
-  async getAllGroups(): Promise<ErrorGroupStats[]> {
+  async getAllGroups(service: string, version: string, pageSize: number):
+      Promise<ErrorGroupStats[]> {
     const id = await this.getProjectId();
     const options = {
-      uri: [API, id, 'groupStats?' + ONE_HOUR_API].join('/'),
+      uri: [
+        API, id,
+        'groupStats?' + ONE_HOUR_API +
+            `&serviceFilter.service=${service}&serviceFilter.version=${
+                version}&pageSize=${pageSize}`
+      ].join('/'),
       method: 'GET'
     };
     const r = await this.request_(options);

--- a/utils/errors-api-transport.ts
+++ b/utils/errors-api-transport.ts
@@ -52,12 +52,6 @@ export class ErrorsApiTransport extends AuthClient {
     super(config, logger);
   }
 
-  async deleteAllEvents() {
-    const id = await this.getProjectId();
-    const options = {uri: [API, id, 'events'].join('/'), method: 'DELETE'};
-    return this.request_(options);
-  }
-
   async getAllGroups(service: string, version: string, pageSize: number):
       Promise<ErrorGroupStats[]> {
     const id = await this.getProjectId();


### PR DESCRIPTION
* The timeout used for waiting for the API to report an error event has been increased.
* The system tests only poll for error events for a specific service and version.
* The page size has been increased when requesting reported errors.
* Increase polling timeout to avoid using the API too much to hit quota exceeded errors.
* Error items are not deleted after the test.  This is needed to avoid conflicting with concurrent runs of the system test because it is not possible to delete error items only associated with a particular test.