### PR TITLE
chore: fix test config to include skipped tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint samples/ && gts check && jsgl --local .",
     "presystem-test": "npm run compile",
     "system-test": "nyc --exclude=\"error-message.js\" mocha  build/system-test/**/*.js",
-    "cover": "nyc --exclude=\"fuzzer.js\" --reporter=lcov mocha build/test/unit/**/*.js && nyc report",
+    "cover": "nyc --exclude=\"fuzzer.js\" --reporter=lcov mocha build/test/unit/*.js build/test/unit/**/*.js && nyc report",
     "presamples-test": "npm run compile",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "test-no-cover": "mocha build/test/unit/**/*.js --timeout 20000",


### PR DESCRIPTION
The test config was only running tests that were in directories
within the `test/unit` directory.  Now those tests as well as
test files in the `test/unit` directory itself are run.