### PR TITLE
chore: change sort order for retrieving err items

### DIFF
--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -496,7 +496,8 @@ describe('error-reporting', () => {
           await transport.getAllGroups(SERVICE, VERSION, PAGE_SIZE);
       assert.ok(allGroups, 'Failed to get groups from the Error Reporting API');
 
-      console.log(JSON.stringify(allGroups.map(group => group.representative.message.split('\n')[0])));
+      console.log(JSON.stringify(
+          allGroups.map(group => group.representative.message.split('\n')[0])));
 
       const filteredGroups = allGroups!.filter(errItem => {
         return (

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -496,6 +496,8 @@ describe('error-reporting', () => {
           await transport.getAllGroups(SERVICE, VERSION, PAGE_SIZE);
       assert.ok(allGroups, 'Failed to get groups from the Error Reporting API');
 
+      console.log(JSON.stringify(allGroups.map(group => group.representative.message.split('\n')[0])));
+
       const filteredGroups = allGroups!.filter(errItem => {
         return (
             errItem && errItem.representative &&

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -440,7 +440,7 @@ describe('error-reporting', () => {
 
   const SERVICE = buildName('service-name');
   const VERSION = buildName('service-version');
-  const PAGE_SIZE = 100;
+  const PAGE_SIZE = 1000;
 
   let errors: ErrorReporting;
   let transport: ErrorsApiTransport;
@@ -581,7 +581,7 @@ describe('error-reporting', () => {
 
   it('Should correctly publish an error that is an Error object',
      async function verifyErrors() {
-       this.timeout(TIMEOUT * 2);
+       this.timeout(TIMEOUT);
        const errorId = buildName('with-error-constructor');
        function expectedTopOfStack() {
          return new Error(errorId);
@@ -594,7 +594,7 @@ describe('error-reporting', () => {
 
   it('Should correctly publish an error that is a string',
      async function(this) {
-       this.timeout(TIMEOUT * 2);
+       this.timeout(TIMEOUT);
        const errorId = buildName('with-string');
        await verifyReporting(errorId, message => {
          return message.startsWith(errorId + '\n');
@@ -603,14 +603,14 @@ describe('error-reporting', () => {
 
   it('Should correctly publish an error that is undefined',
      async function(this) {
-       this.timeout(TIMEOUT * 2);
+       this.timeout(TIMEOUT);
        await verifyReporting(undefined, message => {
          return message.startsWith('undefined\n');
        }, 1, TIMEOUT);
      });
 
   it('Should correctly publish an error that is null', async function(this) {
-    this.timeout(TIMEOUT * 2);
+    this.timeout(TIMEOUT);
     await verifyReporting(null, message => {
       return message.startsWith('null\n');
     }, 1, TIMEOUT);
@@ -618,7 +618,7 @@ describe('error-reporting', () => {
 
   it('Should correctly publish an error that is a plain object',
      async function(this) {
-       this.timeout(TIMEOUT * 2);
+       this.timeout(TIMEOUT);
        await verifyReporting({someKey: 'someValue'}, message => {
          return message.startsWith('[object Object]\n');
        }, 1, TIMEOUT);
@@ -626,7 +626,7 @@ describe('error-reporting', () => {
 
   it('Should correctly publish an error that is a number',
      async function(this) {
-       this.timeout(TIMEOUT * 2);
+       this.timeout(TIMEOUT);
        const num = new Date().getTime();
        await verifyReporting(num, message => {
          return message.startsWith('' + num + '\n');
@@ -635,7 +635,7 @@ describe('error-reporting', () => {
 
   it('Should correctly publish an error that is of an unknown type',
      async function(this) {
-       this.timeout(TIMEOUT * 2);
+       this.timeout(TIMEOUT);
        const bool = true;
        await verifyReporting(bool, message => {
          return message.startsWith('true\n');
@@ -644,7 +644,7 @@ describe('error-reporting', () => {
 
   it('Should correctly publish errors using an error builder',
      async function(this) {
-       this.timeout(TIMEOUT * 2);
+       this.timeout(TIMEOUT);
        const errorId = buildName('with-error-builder');
        // Use an IIFE with the name `definitionSiteFunction` to use later to
        // ensure the stack trace of the point where the error message was
@@ -674,7 +674,7 @@ describe('error-reporting', () => {
      });
 
   it('Should report unhandledRejections if enabled', async function(this) {
-    this.timeout(TIMEOUT * 5);
+    this.timeout(TIMEOUT);
     reinitialize({reportUnhandledRejections: true});
     const rejectValue = buildName('report-promise-rejection');
     function expectedTopOfStack() {
@@ -706,7 +706,7 @@ describe('error-reporting', () => {
   });
 
   it('Should not report unhandledRejections if disabled', async function(this) {
-    this.timeout(TIMEOUT * 2);
+    this.timeout(TIMEOUT);
     reinitialize({reportUnhandledRejections: false});
     const rejectValue = buildName('do-not-report-promise-rejection');
     const canaryValue = buildName('canary-value');

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -491,17 +491,19 @@ describe('error-reporting', () => {
       timeout: number) {
     const start = Date.now();
     let groups: ErrorGroupStats[] = [];
-    const shouldContinue = () => groups.length < maxCount && (Date.now() - start) <= timeout;
+    const shouldContinue = () =>
+        groups.length < maxCount && (Date.now() - start) <= timeout;
     while (shouldContinue()) {
       let prevPageToken: string|undefined;
       let allGroups: ErrorGroupStats[]|undefined;
-      let page = 1;
+      const page = 1;
       while (shouldContinue() && (!allGroups || allGroups.length > 0)) {
-        const response =
-          await transport.getAllGroups(SERVICE, VERSION, PAGE_SIZE, prevPageToken);
+        const response = await transport.getAllGroups(
+            SERVICE, VERSION, PAGE_SIZE, prevPageToken);
         prevPageToken = response.nextPageToken;
         allGroups = response.errorGroupStats || [];
-        assert.ok(allGroups, 'Failed to get groups from the Error Reporting API');
+        assert.ok(
+            allGroups, 'Failed to get groups from the Error Reporting API');
 
         const filteredGroups = allGroups!.filter(errItem => {
           return (

--- a/utils/errors-api-transport.ts
+++ b/utils/errors-api-transport.ts
@@ -52,8 +52,9 @@ export class ErrorsApiTransport extends AuthClient {
     super(config, logger);
   }
 
-  async getAllGroups(service: string, version: string, pageSize: number, pageToken?: string):
-      Promise<GroupStatesResponse> {
+  async getAllGroups(
+      service: string, version: string, pageSize: number,
+      pageToken?: string): Promise<GroupStatesResponse> {
     const id = await this.getProjectId();
     const options = {
       uri: [
@@ -61,7 +62,7 @@ export class ErrorsApiTransport extends AuthClient {
         'groupStats?' + ONE_HOUR_API +
             `&serviceFilter.service=${service}&serviceFilter.version=${
                 version}&pageSize=${pageSize}&order=LAST_SEEN_DESC` +
-                  (pageToken ? `&pageToken=${pageToken}` : '')
+            (pageToken ? `&pageToken=${pageToken}` : '')
       ].join('/'),
       method: 'GET'
     };

--- a/utils/errors-api-transport.ts
+++ b/utils/errors-api-transport.ts
@@ -60,7 +60,7 @@ export class ErrorsApiTransport extends AuthClient {
         API, id,
         'groupStats?' + ONE_HOUR_API +
             `&serviceFilter.service=${service}&serviceFilter.version=${
-                version}&pageSize=${pageSize}`
+                version}&pageSize=${pageSize}&order=CREATED_DESC`
       ].join('/'),
       method: 'GET'
     };

--- a/utils/errors-api-transport.ts
+++ b/utils/errors-api-transport.ts
@@ -37,8 +37,8 @@ export interface ErrorGroupStats {
 }
 
 export interface GroupStatesResponse {
-  errorGroupStats: ErrorGroupStats[];
-  nextPageToken: string;
+  errorGroupStats?: ErrorGroupStats[];
+  nextPageToken?: string;
   timeRangeBegin: string;
 }
 
@@ -52,19 +52,20 @@ export class ErrorsApiTransport extends AuthClient {
     super(config, logger);
   }
 
-  async getAllGroups(service: string, version: string, pageSize: number):
-      Promise<ErrorGroupStats[]> {
+  async getAllGroups(service: string, version: string, pageSize: number, pageToken?: string):
+      Promise<GroupStatesResponse> {
     const id = await this.getProjectId();
     const options = {
       uri: [
         API, id,
         'groupStats?' + ONE_HOUR_API +
             `&serviceFilter.service=${service}&serviceFilter.version=${
-                version}&pageSize=${pageSize}&order=LAST_SEEN_DESC`
+                version}&pageSize=${pageSize}&order=LAST_SEEN_DESC` +
+                  (pageToken ? `&pageToken=${pageToken}` : '')
       ].join('/'),
       method: 'GET'
     };
-    const r = await this.request_(options);
-    return r.body.errorGroupStats || [];
+    const response = await this.request_(options);
+    return response.body;
   }
 }

--- a/utils/errors-api-transport.ts
+++ b/utils/errors-api-transport.ts
@@ -60,7 +60,7 @@ export class ErrorsApiTransport extends AuthClient {
         API, id,
         'groupStats?' + ONE_HOUR_API +
             `&serviceFilter.service=${service}&serviceFilter.version=${
-                version}&pageSize=${pageSize}&order=CREATED_DESC`
+                version}&pageSize=${pageSize}&order=LAST_SEEN_DESC`
       ].join('/'),
       method: 'GET'
     };


### PR DESCRIPTION
This is being done to address the system test flakiness by having
the most recently created error item listed first in the list
of error items retrieved from the error reporting service.