### PR TITLE
chore: increase the system test delay

### DIFF
--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -496,7 +496,6 @@ describe('error-reporting', () => {
     while (shouldContinue()) {
       let prevPageToken: string|undefined;
       let allGroups: ErrorGroupStats[]|undefined;
-      const page = 1;
       while (shouldContinue() && (!allGroups || allGroups.length > 0)) {
         const response = await transport.getAllGroups(
             SERVICE, VERSION, PAGE_SIZE, prevPageToken);
@@ -514,7 +513,7 @@ describe('error-reporting', () => {
               messageTest(errItem.representative.message));
         });
         groups = groups.concat(filteredGroups);
-        await delay(5000);
+        await delay(15000);
       }
     }
 


### PR DESCRIPTION
This change is made to address the error:
```
   Error: Quota exceeded for quota metric
   'clouderrorreporting.googleapis.com/manage_error_events_data_requests'
   and limit 'ManageErrorEventsDataRequestsPerMinutePerUser' of
   service 'clouderrorreporting.googleapis.com'
```