### PR TITLE
feat: add a new `reportMode` configuration option

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -276,6 +276,11 @@ export class Configuration {
   _gatherLocalConfiguration() {
     const hasEnvCheck = has(this._givenConfiguration, 'ignoreEnvironmentCheck');
     const hasReportMode = has(this._givenConfiguration, 'reportMode');
+    if (hasEnvCheck) {
+      this._logger.warn(
+          'The "ignoreEnvironmentCheck" config option is deprecated.  ' +
+          'Use the "reportMode" config option instead.');
+    }
     if (hasEnvCheck && hasReportMode) {
       this._logger.warn([
         'Both the "ignoreEnvironmentCheck" and "reportMode" configuration options',

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -263,7 +263,7 @@ export class Configuration {
       this._reportMode =
           this._givenConfiguration.reportMode.toLowerCase() as ReportMode;
     }
-    if (this.isReportingEnabled() && !this.getCanReportErrorsToAPI()) {
+    if (this.isReportingEnabled() && !this.getShouldReportErrorsToAPI()) {
       this._logger.warn([
         'The stackdriver error reporting client is configured to report errors',
         'if and only if the NODE_ENV environment variable is set to "production".',
@@ -330,13 +330,16 @@ export class Configuration {
     return this._projectId;
   }
   /**
-   * Returns the _shouldReportErrorsToAPI property on the instance.
+   * Returns whether this configuration specifies that errors should be
+   * reported to the error reporting API.  That is, "reportMode" is
+   * either set to "always" or it is set to "production" and the value
+   * of the NODE_ENV environment variable is "production".
    * @memberof Configuration
    * @public
    * @function getShouldReportErrorsToAPI
-   * @returns {Boolean} - returns the _shouldReportErrorsToAPI property
+   * @returns {Boolean} - whether errors should be reported to the API
    */
-  getCanReportErrorsToAPI() {
+  getShouldReportErrorsToAPI() {
     return this._reportMode === 'always' ||
         (this._reportMode === 'production' &&
          (process.env.NODE_ENV || '').toLowerCase() === 'production');

--- a/src/google-apis/auth-client.ts
+++ b/src/google-apis/auth-client.ts
@@ -164,7 +164,7 @@ export class RequestHandler extends Service {
         cb(null, null, {});
         return;
       }
-      if (this._config.getCanReportErrorsToAPI()) {
+      if (this._config.getShouldReportErrorsToAPI()) {
         this.request(
             {
               uri: 'events:report',

--- a/src/google-apis/auth-client.ts
+++ b/src/google-apis/auth-client.ts
@@ -159,8 +159,12 @@ export class RequestHandler extends Service {
       userCb?:
           (err: Error|null, response: http.ServerResponse|null,
            body: {}) => void) {
-    const cb: Function = (is.function(userCb) ? userCb : RequestHandler.noOp)!;
-      if (this._config.getShouldReportErrorsToAPI()) {
+      const cb: Function = (is.function(userCb) ? userCb : RequestHandler.noOp)!;
+      if (!this._config.isReportingEnabled()) {
+        cb(null, null, {});
+        return;
+      }
+      if (this._config.getCanReportErrorsToAPI()) {
         this.request(
             {
               uri: 'events:report',
@@ -181,14 +185,14 @@ export class RequestHandler extends Service {
             });
       } else {
         cb(new Error([
-             'Stackdriver error reporting client has not been configured to send',
-             'errors, please check the NODE_ENV environment variable and make sure',
-             'it is set to "production" or set the ignoreEnvironmentCheck property',
-             'to true in the runtime configuration object',
+             'The stackdriver error reporting client is configured to report errors',
+             'if and only if the NODE_ENV environment variable is set to "production".',
+             'Errors will not be reported.  To have errors always reported, regardless of the',
+             'value of NODE_ENV, set the reportMode configuration option to "always".'
            ].join(' ')),
            null, null);
       }
-  }
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,9 +52,14 @@ export type RestifyRequestHandler = (req: any, res: any, next: Function) => any;
  *  running on
  * @property {String} [serviceContext.version] - the version the hosting
  *  application is currently labelled as
- * @property {Boolean} [ignoreEnvironmentCheck] - flag indicating whether or not
- *  to communicate errors to the Stackdriver service even if NODE_ENV is not set
- *  to production
+ * @property {String} [reportMode] - flag indicating whether or not
+ *  to communicate errors to the Stackdriver service.  Possible values are:
+ *  -> 'production' (default)
+ *     -> Only report errors if NODE_ENV is set to "production".
+ *  -> 'always'
+ *     -> Always report errors regardless of the value of NODE_ENV.
+ *  -> 'never'
+ *     -> Never report errors regardless of the value of NODE_ENV.
  */
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,9 @@ export type RestifyRequestHandler = (req: any, res: any, next: Function) => any;
  *  running on
  * @property {String} [serviceContext.version] - the version the hosting
  *  application is currently labelled as
+ * @property {Boolean} [ignoreEnvironmentCheck] - flag indicating whether or not
+ *  to communicate errors to the Stackdriver service even if NODE_ENV is not set
+ *  to production
  * @property {String} [reportMode] - flag indicating whether or not
  *  to communicate errors to the Stackdriver service.  Possible values are:
  *  -> 'production' (default)

--- a/system-test/error-reporting.ts
+++ b/system-test/error-reporting.ts
@@ -335,10 +335,7 @@ describe('Expected Behavior', () => {
      done => {
        env.sterilizeProcess().setKeyFilename().setProjectId();
        process.env.NODE_ENV = 'null';
-       const logger = createLogger({
-         logLevel: 5,
-         reportMode: 'production'
-        });
+       const logger = createLogger({logLevel: 5, reportMode: 'production'});
        const client =
            new RequestHandler(new Configuration(undefined, logger), logger);
        client.sendError({} as ErrorMessage, (err, response) => {

--- a/test/unit/configuration.ts
+++ b/test/unit/configuration.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 import * as is from 'is';
 import merge = require('lodash.merge');
 import {FakeConfiguration as Configuration} from '../fixtures/configuration';
-import {ConfigurationOptions} from '../../src/configuration';
+import {ConfigurationOptions, Logger} from '../../src/configuration';
 import {Fuzzer} from '../../utils/fuzzer';
 import {deepStrictEqual} from '../util';
 const level = process.env.GCLOUD_ERRORS_LOGLEVEL;
@@ -117,6 +117,41 @@ describe('Configuration class', () => {
           process.env.NODE_ENV = nodeEnv;
         }
       });
+
+      it('Should print a deprecation warning if "ignoreEvnironmentCheck" is used',
+         () => {
+           let warnText = '';
+           const logger = {
+             warn: (text) => {
+               warnText += text + '\n';
+             }
+           } as Logger;
+           // tslint:disable-next-line:no-unused-expression
+           new Configuration({ignoreEnvironmentCheck: true}, logger);
+           assert.strictEqual(
+               warnText,
+               'The "ignoreEnvironmentCheck" config option is deprecated.  ' +
+                   'Use the "reportMode" config option instead.\n');
+         });
+
+      it('Should print a warning if both "ignoreEnvironmentCheck" and "reportMode" are specified',
+         () => {
+           let warnText = '';
+           const logger = {
+             warn: (text) => {
+               warnText += text + '\n';
+             }
+           } as Logger;
+           // tslint:disable-next-line:no-unused-expression
+           new Configuration(
+               {ignoreEnvironmentCheck: true, reportMode: 'never'}, logger);
+           assert.strictEqual(
+               warnText,
+               'The "ignoreEnvironmentCheck" config option is deprecated.  ' +
+                   'Use the "reportMode" config option instead.\nBoth the "ignoreEnvironmentCheck" ' +
+                   'and "reportMode" configuration options have been specified.  The "reportMode" ' +
+                   'option will take precedence.\n');
+         });
 
       it('Should set "reportMode" to "always" if "ignoreEnvironmentCheck" is true',
          () => {

--- a/test/unit/configuration.ts
+++ b/test/unit/configuration.ts
@@ -261,6 +261,21 @@ describe('Configuration class', () => {
       });
     });
     describe('exception behaviour', () => {
+      it('Should throw if invalid type for reportMode', () => {
+        assert.throws(() => {
+          // tslint:disable-next-line:no-unused-expression
+          new Configuration(
+              {reportMode: new Date()} as {} as ConfigurationOptions, logger);
+        });
+      });
+      it('Should throw if invalid value for reportMode', () => {
+        assert.throws(() => {
+          // tslint:disable-next-line:no-unused-expression
+          new Configuration(
+              {reportMode: 'invalid-mode'} as {} as ConfigurationOptions,
+              logger);
+        });
+      });
       it('Should throw if invalid type for key', () => {
         assert.throws(() => {
           // we are intentionally providing an invalid configuration

--- a/test/unit/configuration.ts
+++ b/test/unit/configuration.ts
@@ -138,46 +138,46 @@ describe('Configuration class', () => {
         assert.strictEqual(conf.isReportingEnabled(), false);
       });
 
-      it('Should state reporting can proceed with mode "production" and env "production"',
+      it('Should state reporting should proceed with mode "production" and env "production"',
          () => {
            process.env.NODE_ENV = 'production';
            const conf = new Configuration({reportMode: 'production'}, logger);
-           assert.strictEqual(conf.getCanReportErrorsToAPI(), true);
+           assert.strictEqual(conf.getShouldReportErrorsToAPI(), true);
          });
 
-      it('Should state reporting cannot proceed with mode "production" and env not "production"',
+      it('Should state reporting should not proceed with mode "production" and env not "production"',
          () => {
            process.env.NODE_ENV = 'dev';
            const conf = new Configuration({reportMode: 'production'}, logger);
-           assert.strictEqual(conf.getCanReportErrorsToAPI(), false);
+           assert.strictEqual(conf.getShouldReportErrorsToAPI(), false);
          });
 
-      it('Should state reporting can proceed with mode "always" and env "production"',
+      it('Should state reporting should proceed with mode "always" and env "production"',
          () => {
            process.env.NODE_ENV = 'production';
            const conf = new Configuration({reportMode: 'always'}, logger);
-           assert.strictEqual(conf.getCanReportErrorsToAPI(), true);
+           assert.strictEqual(conf.getShouldReportErrorsToAPI(), true);
          });
 
-      it('Should state reporting can proceed with mode "always" and env not "production"',
+      it('Should state reporting should proceed with mode "always" and env not "production"',
          () => {
            process.env.NODE_ENV = 'dev';
            const conf = new Configuration({reportMode: 'always'}, logger);
-           assert.strictEqual(conf.getCanReportErrorsToAPI(), true);
+           assert.strictEqual(conf.getShouldReportErrorsToAPI(), true);
          });
 
-      it('Should state reporting cannot proceed with mode "never" and env "production"',
+      it('Should state reporting should not proceed with mode "never" and env "production"',
          () => {
            process.env.NODE_ENV = 'production';
            const conf = new Configuration({reportMode: 'never'}, logger);
-           assert.strictEqual(conf.getCanReportErrorsToAPI(), false);
+           assert.strictEqual(conf.getShouldReportErrorsToAPI(), false);
          });
 
-      it('Should state reporting cannot proceed with mode "never" and env not "production"',
+      it('Should state reporting should not proceed with mode "never" and env not "production"',
          () => {
            process.env.NODE_ENV = 'dev';
            const conf = new Configuration({reportMode: 'never'}, logger);
-           assert.strictEqual(conf.getCanReportErrorsToAPI(), false);
+           assert.strictEqual(conf.getShouldReportErrorsToAPI(), false);
          });
     });
     describe('exception behaviour', () => {

--- a/test/unit/google-apis/auth-client.ts
+++ b/test/unit/google-apis/auth-client.ts
@@ -114,7 +114,7 @@ describe('RequestHandler', () => {
 
   it('should not issue a warning if disabled and cannot communicate with the API',
      (done) => {
-       process.env.NODE_ENV = 'ev';
+       process.env.NODE_ENV = 'dev';
        verifyReportedMessage(
            {reportMode: 'never'},
            null,  // no access token error
@@ -132,8 +132,29 @@ describe('RequestHandler', () => {
            done);
      });
 
+  it('should not issue a warning with a default config and can communicate with the API',
+     (done) => {
+       process.env.NODE_ENV = 'production';
+       verifyReportedMessage(
+           {},
+           null,  // no access token error
+           {},    // no expected logs
+           done);
+     });
+
+  it('should not issue a warning if it can communicate with the API',
+     (done: () => void) => {
+       const config = {ignoreEnvironmentCheck: true};
+       const warn =
+           'The "ignoreEnvironmentCheck" config option is deprecated.  ' +
+           'Use the "reportMode" config option instead.';
+       verifyReportedMessage(config, null, {warn}, () => {
+         verifyReportedMessage(config, undefined, {warn}, done);
+       });
+     });
+
   it('should issue a warning if enabled and cannot communicate with the API', (done) => {
-    process.env.NODE_ENV = 'ev';
+    process.env.NODE_ENV = 'dev';
     verifyReportedMessage(
         {reportMode: 'production'},
         null,  // no access token error
@@ -147,6 +168,23 @@ describe('RequestHandler', () => {
         },
         done);
   });
+
+  it('should issue a warning with a default config and cannot communicate with the API',
+     (done) => {
+       process.env.NODE_ENV = 'dev';
+       verifyReportedMessage(
+           {},
+           null,  // no access token error
+           {
+             warn:
+                 'The stackdriver error reporting client is configured to report ' +
+                 'errors if and only if the NODE_ENV environment variable is set to ' +
+                 '"production". Errors will not be reported.  To have errors always ' +
+                 'reported, regardless of the value of NODE_ENV, set the reportMode ' +
+                 'configuration option to "always".'
+           },
+           done);
+     });
 
   it('should issue a warning if it cannot communicate with the API',
      (done: () => void) => {
@@ -162,16 +200,5 @@ describe('RequestHandler', () => {
                  'Use the "reportMode" config option instead.'
            },
            done);
-     });
-
-  it('should not issue a warning if it can communicate with the API',
-     (done: () => void) => {
-       const config = {ignoreEnvironmentCheck: true};
-       const warn =
-           'The "ignoreEnvironmentCheck" config option is deprecated.  ' +
-           'Use the "reportMode" config option instead.';
-       verifyReportedMessage(config, null, {warn}, () => {
-         verifyReportedMessage(config, undefined, {warn}, done);
-       });
      });
 });

--- a/test/unit/google-apis/auth-client.ts
+++ b/test/unit/google-apis/auth-client.ts
@@ -157,6 +157,9 @@ describe('RequestHandler', () => {
              error: 'Unable to find credential information on instance. This ' +
                  'library will be unable to communicate with the Stackdriver API to ' +
                  'save errors.  Message: ' + message,
+             warn:
+                 'The "ignoreEnvironmentCheck" config option is deprecated.  ' +
+                 'Use the "reportMode" config option instead.'
            },
            done);
      });
@@ -164,8 +167,11 @@ describe('RequestHandler', () => {
   it('should not issue a warning if it can communicate with the API',
      (done: () => void) => {
        const config = {ignoreEnvironmentCheck: true};
-       verifyReportedMessage(config, null, {}, () => {
-         verifyReportedMessage(config, undefined, {}, done);
+       const warn =
+           'The "ignoreEnvironmentCheck" config option is deprecated.  ' +
+           'Use the "reportMode" config option instead.';
+       verifyReportedMessage(config, null, {warn}, () => {
+         verifyReportedMessage(config, undefined, {warn}, done);
        });
      });
 });

--- a/test/unit/google-apis/auth-client.ts
+++ b/test/unit/google-apis/auth-client.ts
@@ -147,4 +147,25 @@ describe('RequestHandler', () => {
         },
         done);
   });
+
+  it('should issue a warning if it cannot communicate with the API',
+     (done: () => void) => {
+       const config = {ignoreEnvironmentCheck: true};
+       const message = 'Test Error';
+       verifyReportedMessage(
+           config, new Error(message), {
+             error: 'Unable to find credential information on instance. This ' +
+                 'library will be unable to communicate with the Stackdriver API to ' +
+                 'save errors.  Message: ' + message,
+           },
+           done);
+     });
+
+  it('should not issue a warning if it can communicate with the API',
+     (done: () => void) => {
+       const config = {ignoreEnvironmentCheck: true};
+       verifyReportedMessage(config, null, {}, () => {
+         verifyReportedMessage(config, undefined, {}, done);
+       });
+     });
 });

--- a/test/unit/google-apis/auth-client.ts
+++ b/test/unit/google-apis/auth-client.ts
@@ -21,14 +21,18 @@ import {deepStrictEqual} from '../../util';
 
 function verifyReportedMessage(
     config1: ConfigurationOptions, errToReturn: Error|null|undefined,
-    expectedLogs: {error?: string; info?: string;}, done: () => void) {
+    expectedLogs: {error?: string; info?: string; warn?: string;},
+    done: () => void) {
   class ServiceStub {
     authClient: {};
     request: {};
     constructor() {
       this.authClient = {
         async getAccessToken() {
-          throw errToReturn;
+          if (errToReturn) {
+            throw errToReturn;
+          }
+          return 'some-token';
         },
       };
       this.request = () => {};
@@ -41,7 +45,7 @@ function verifyReportedMessage(
                            },
                          }).RequestHandler;
 
-  const logs: {error?: string; info?: string;} = {};
+  const logs: {error?: string; info?: string; warn?: string} = {};
   const logger = {
     error(text: string) {
       if (!logs.error) {
@@ -55,6 +59,12 @@ function verifyReportedMessage(
       }
       logs.info += text;
     },
+    warn(text: string) {
+      if (!logs.warn) {
+        logs.warn = '';
+      }
+      logs.warn += text;
+    }
   } as {} as Logger;
   const config2 = new Configuration(config1, logger);
   // tslint:disable-next-line:no-unused-expression
@@ -65,9 +75,22 @@ function verifyReportedMessage(
   });
 }
 describe('RequestHandler', () => {
+  let nodeEnv: string|undefined;
+  beforeEach(() => {
+    nodeEnv = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    if (nodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = nodeEnv;
+    }
+  });
+
   it('should not request OAuth2 token if key is provided', done => {
-    const config = {
-      ignoreEnvironmentCheck: true,
+    const config: ConfigurationOptions = {
+      reportMode: 'always',
       key: 'key',
     };
     const message = 'Made OAuth2 Token Request';
@@ -78,24 +101,50 @@ describe('RequestHandler', () => {
         done);
   }).timeout(8000);
 
-  it('should issue a warning if it cannot communicate with the API',
-     (done: () => void) => {
-       const config = {ignoreEnvironmentCheck: true};
-       const message = 'Test Error';
+
+  it('should not issue a warning if disabled and can communicate with the API',
+     (done) => {
+       process.env.NODE_ENV = 'production';
        verifyReportedMessage(
-           config, new Error(message), {
-             error: 'Unable to find credential information on instance. This ' +
-                 'library will be unable to communicate with the Stackdriver API to ' +
-                 'save errors.  Message: ' + message,
-           },
+           {reportMode: 'never'},
+           null,  // no access token error
+           {},    // no expected logs
            done);
      });
 
-  it('should not issue a warning if it can communicate with the API',
-     (done: () => void) => {
-       const config = {ignoreEnvironmentCheck: true};
-       verifyReportedMessage(config, null, {}, () => {
-         verifyReportedMessage(config, undefined, {}, done);
-       });
+  it('should not issue a warning if disabled and cannot communicate with the API',
+     (done) => {
+       process.env.NODE_ENV = 'ev';
+       verifyReportedMessage(
+           {reportMode: 'never'},
+           null,  // no access token error
+           {},    // no expected logs
+           done);
      });
+
+  it('should not issue a warning if enabled and can communicate with the API',
+     (done) => {
+       process.env.NODE_ENV = 'production';
+       verifyReportedMessage(
+           {reportMode: 'production'},
+           null,  // no access token error
+           {},    // no expected logs
+           done);
+     });
+
+  it('should issue a warning if enabled and cannot communicate with the API', (done) => {
+    process.env.NODE_ENV = 'ev';
+    verifyReportedMessage(
+        {reportMode: 'production'},
+        null,  // no access token error
+        {
+          warn:
+              'The stackdriver error reporting client is configured to report ' +
+              'errors if and only if the NODE_ENV environment variable is set to ' +
+              '"production". Errors will not be reported.  To have errors always ' +
+              'reported, regardless of the value of NODE_ENV, set the reportMode ' +
+              'configuration option to "always".'
+        },
+        done);
+  });
 });


### PR DESCRIPTION
Adds the `reportMode` configuration option.  The
`ignoreEnvironmentCheck` configuration option is now
deprecated, and the `reportMode` option should be used
instead.

In particular, the `reportMode` can have one of three values:
* 'production' (default)
   - Only report errors if NODE_ENV is set to "production".:
* 'always'
   - Always report errors regardless of the value of NODE_ENV.
* 'never'
   - Never report errors regardless of the value of NODE_ENV.

Fixes #127 