### PR TITLE
Release @google-cloud/error-reporting v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://www.npmjs.com/package/@google-cloud/error-reporting?activeTab=versions
 
+## v0.6.0
+
+01-22-2019 09:59 PST
+
+### New Features
+- feat: add a new `reportMode` configuration option ([#295](https://github.com/googleapis/nodejs-error-reporting/pull/295))
+
 ## v0.5.2
 
 12-20-2018 11:49 PST

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/error-reporting",
   "description": "Stackdriver Error Reporting Client Library for Node.js",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -15,7 +15,7 @@
     "test": "mocha system-test/*.test.js --timeout=600000"
   },
   "dependencies": {
-    "@google-cloud/error-reporting": "^0.5.2",
+    "@google-cloud/error-reporting": "^0.6.0",
     "express": "^4.16.3",
     "yargs": "^12.0.0"
   },


### PR DESCRIPTION
This pull request was generated using releasetool.