### PR TITLE
refactor: cleanup types for reportManualError

### DIFF
--- a/src/interfaces/manual.ts
+++ b/src/interfaces/manual.ts
@@ -16,6 +16,7 @@
 
 import * as http from 'http';
 import * as is from 'is';
+import {any} from 'joi';
 
 import {ErrorMessage} from '../classes/error-message';
 import {Configuration, Logger} from '../configuration';
@@ -26,6 +27,9 @@ import {Request} from '../request-extractors/manual';
 
 export type Callback =
     (err: Error|null, response: http.ServerResponse|null, body: {}) => void;
+
+// tslint:disable-next-line:no-any
+type AnyError = any;
 
 /**
  * The handler setup function serves to produce a bound instance of the
@@ -60,11 +64,25 @@ export function handlerSetup(
    * @returns {ErrorMessage} - returns the error message created through with
    * the parameters given.
    */
-  // the `err` argument can be anything, including `null` and `undefined`
+  function reportManualError(err: AnyError): ErrorMessage;
+  function reportManualError(err: AnyError, request: Request): ErrorMessage;
   function reportManualError(
-      err: any,  // tslint:disable-line:no-any
-      request?: Request|Callback|string, additionalMessage?: Callback|string|{},
-      callback?: Callback|{}|string) {
+      err: AnyError, additionalMessage: string): ErrorMessage;
+  function reportManualError(err: AnyError, callback: Callback): ErrorMessage;
+  function reportManualError(
+      err: AnyError, request: Request, callback: Callback): ErrorMessage;
+  function reportManualError(
+      err: AnyError, request: Request, additionalMessage: string): ErrorMessage;
+  function reportManualError(
+      err: AnyError, additionalMessage: string,
+      callback: Callback): ErrorMessage;
+  function reportManualError(
+      err: AnyError, request: Request, additionalMessage: string,
+      callback: Callback): ErrorMessage;
+  function reportManualError(
+      err: AnyError, request?: Request|Callback|string,
+      additionalMessage?: Callback|string|{},
+      callback?: Callback|{}|string): ErrorMessage {
     let em;
     if (is.string(request)) {
       // no request given

--- a/src/interfaces/manual.ts
+++ b/src/interfaces/manual.ts
@@ -16,7 +16,6 @@
 
 import * as http from 'http';
 import * as is from 'is';
-import {any} from 'joi';
 
 import {ErrorMessage} from '../classes/error-message';
 import {Configuration, Logger} from '../configuration';

--- a/test/unit/interfaces/manual.ts
+++ b/test/unit/interfaces/manual.ts
@@ -27,6 +27,7 @@ const config = new Configuration({});
 import {ErrorMessage} from '../../../src/classes/error-message';
 import {RequestHandler} from '../../../src/google-apis/auth-client';
 import {RequestInformationContainer} from '../../../src/classes/request-information-container';
+import {Request} from '../../../src/request-extractors/manual';
 
 describe('Manual handler', () => {
   // nock.disableNetConnect();
@@ -117,17 +118,21 @@ describe('Manual handler', () => {
       assert.strictEqual(r.context.httpRequest.method, 'TACKEY');
     });
     it('Should ignore arguments', done => {
-      const r = report('hockey', () => {
-        done();
-      }, 'field');
+      const r = report(
+          'hockey', (() => {
+                      done();
+                    }) as unknown as string,
+          'field' as unknown as manual.Callback);
       assert(
           r.message.match('hockey') && !r.message.match('field'),
           'string after callback should be ignored');
     });
     it('Should ignore arguments', done => {
-      const r = report('passkey', () => {
-        done();
-      }, {method: 'HONK'});
+      const r = report(
+          'passkey', (() => {
+                       done();
+                     }) as unknown as string,
+          {method: 'HONK'} as unknown as manual.Callback);
       assert.notEqual(r.context.httpRequest.method, 'HONK');
     });
     it('Should allow null arguments as placeholders', done => {
@@ -137,21 +142,25 @@ describe('Manual handler', () => {
       assert(r.message.match(/pokey/), 'string error should propagate');
     });
     it('Should allow explicit undefined', done => {
-      const r = report('Turkey', undefined, undefined, () => {
-        done();
-      });
+      const r = report(
+          'Turkey', undefined as unknown as Request,
+          undefined as unknown as string, () => {
+            done();
+          });
       assert(r.message.match(/Turkey/), 'string error should propagate');
     });
     it('Should allow request to be supplied as undefined', done => {
-      const r = report('turnkey', undefined, 'solution', () => {
-        done();
-      });
+      const r =
+          report('turnkey', undefined as unknown as Request, 'solution', () => {
+            done();
+          });
       assert.strictEqual(r.message, 'solution', 'error should propagate');
     });
     it('Should allow additional message', done => {
-      const r = report('Mickey', {method: 'SNIFF'}, undefined, () => {
-        done();
-      });
+      const r = report(
+          'Mickey', {method: 'SNIFF'}, undefined as unknown as string, () => {
+            done();
+          });
       assert(
           r.message.match(/Mickey/) && !r.message.match(/SNIFF/),
           'string error should propagate');


### PR DESCRIPTION
Fixes: https://github.com/googleapis/nodejs-error-reporting/issues/35

I'm debating if this is semver major for typescript users.