### PR TITLE
fix: properly handle hapi v16+ req.url

### DIFF
--- a/src/request-extractors/hapi.ts
+++ b/src/request-extractors/hapi.ts
@@ -81,10 +81,15 @@ export function hapiRequestInformationExtractor(req?: hapi.Request) {
         return returnObject;
       }
 
-      returnObject
-          .setMethod(req!.method)
-          // TODO: Address the type conflict that requires a cast to string
-          .setUrl(req!.url as {} as string)
+      let urlString: string;
+      if (is.string(req!.url)) {
+        urlString = req!.url as {} as string;
+      } else {
+        urlString = req!.url.pathname;
+      }
+
+      returnObject.setMethod(req!.method)
+          .setUrl(urlString)
           .setUserAgent(req!.headers['user-agent'])
           .setReferrer(req!.headers.referrer)
           .setStatusCode(attemptToExtractStatusCode(req!))

--- a/test/unit/request-extractors/hapi.ts
+++ b/test/unit/request-extractors/hapi.ts
@@ -15,6 +15,7 @@
  */
 
 import * as hapi from 'hapi';
+import {URL} from 'url';
 
 import {hapiRequestInformationExtractor} from '../../../src/request-extractors/hapi';
 import {Fuzzer} from '../../../utils/fuzzer';
@@ -119,6 +120,17 @@ describe('hapiRequestInformationExtractor behaviour', () => {
           hapiRequestInformationExtractor(
               ANOTHER_PARTIAL_REQ_DERIVATION_VALUE as {} as hapi.Request),
           ANOTHER_PARTIAL_REQ_EXPECTED_VALUE);
+    });
+    it('Should deal with hapi v16+ URL objects', () => {
+      const PATH = '/foo/bar';
+      const REQUEST = {
+        ...FULL_REQ_DERIVATION_VALUE,
+        url: new URL(`https://www.SUPER-TEST.com${PATH}`)
+      };
+      const EXPECTED = {...FULL_REQ_EXPECTED_VALUE, url: PATH};
+      deepStrictEqual(
+          hapiRequestInformationExtractor(REQUEST as {} as hapi.Request),
+          EXPECTED);
     });
   });
 });


### PR DESCRIPTION
request.url can be a url.URL object.

Fixes: https://github.com/googleapis/nodejs-error-reporting/issues/196
