### PR TITLE
fix: in Koa2 interface await `next` as a function

### DIFF
--- a/src/interfaces/koa.ts
+++ b/src/interfaces/koa.ts
@@ -42,11 +42,11 @@ export function koaErrorHandler(client: RequestHandler, config: Configuration) {
    * @param {Function} next - the result of the request handlers to yield
    * @returns {Undefined} does not return anything
    */
-  return function*(this: {request: Request; response: Response;}, next: {}) {
+  return function*(this: {request: Request; response: Response;}, next: Function) {
     const svc = config.getServiceContext();
 
     try {
-      yield next;
+      yield next();
     } catch (err) {
       const em = new ErrorMessage()
                      .consumeRequestInformation(koaRequestInformationExtractor(

--- a/src/interfaces/koa.ts
+++ b/src/interfaces/koa.ts
@@ -42,7 +42,8 @@ export function koaErrorHandler(client: RequestHandler, config: Configuration) {
    * @param {Function} next - the result of the request handlers to yield
    * @returns {Undefined} does not return anything
    */
-  return function*(this: {request: Request; response: Response;}, next: Function) {
+  return function*(
+      this: {request: Request; response: Response;}, next: Function) {
     const svc = config.getServiceContext();
 
     try {


### PR DESCRIPTION
Fixes: #335