### PR TITLE
Release @google-cloud/error-reporting v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@
 
 [1]: https://www.npmjs.com/package/@google-cloud/error-reporting?activeTab=versions
 
+## v0.6.2
+
+04-09-2019 11:14 PDT
+
+### Bug Fixes
+
+- fix: in Koa2 interface await `next` as a function ([#336](https://github.com/googleapis/nodejs-error-reporting/pull/336))
+
+### CI/CD
+
+- build: use per-repo publish token ([#327](https://github.com/googleapis/nodejs-error-reporting/pull/327))
+- chore: publish to npm using wombat ([#328](https://github.com/googleapis/nodejs-error-reporting/pull/328))
+
+### Dependencies
+
+- fix(deps): update dependency @google-cloud/common to ^0.32.0 ([#334](https://github.com/googleapis/nodejs-error-reporting/pull/334))
+- chore(deps): update dependency typescript to ~3.4.0
+
+### Internal / Testing Changes
+
+- chore: test Restify 18 in the install tests ([#324](https://github.com/googleapis/nodejs-error-reporting/pull/324))
+
 ## v0.6.1
 
 03-13-2019 16:21 PDT

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/error-reporting",
   "description": "Stackdriver Error Reporting Client Library for Node.js",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -15,7 +15,7 @@
     "test": "mocha system-test/*.test.js --timeout=600000"
   },
   "dependencies": {
-    "@google-cloud/error-reporting": "^0.6.1",
+    "@google-cloud/error-reporting": "^0.6.2",
     "express": "^4.16.3",
     "yargs": "^13.0.0"
   },


### PR DESCRIPTION
This pull request was generated using releasetool.