### PR TITLE
Release @google-cloud/error-reporting v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://www.npmjs.com/package/@google-cloud/error-reporting?activeTab=versions
 
+## v0.6.3
+
+04-11-2019 11:37 PDT
+
+### Bug Fixes
+
+- fix: update Koa2 plugin to await next ([#339](https://github.com/googleapis/nodejs-error-reporting/pull/339))
+
 ## v0.6.2
 
 04-09-2019 11:14 PDT

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/error-reporting",
   "description": "Stackdriver Error Reporting Client Library for Node.js",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -15,7 +15,7 @@
     "test": "mocha system-test/*.test.js --timeout=600000"
   },
   "dependencies": {
-    "@google-cloud/error-reporting": "^0.6.2",
+    "@google-cloud/error-reporting": "^0.6.3",
     "express": "^4.16.3",
     "yargs": "^13.0.0"
   },


### PR DESCRIPTION
This pull request was generated using releasetool.