### PR TITLE
fix: convert AdditionalMessage param into string type CustomMessage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ export class ErrorReporting {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     err: any,
     request?: manualRequestExtractor.Request,
-    additionalMessage?: string | {},
+    customMessage?: string,
     callback?: manualInterface.Callback | {} | string
   ) => ErrorMessage;
   event!: () => ErrorMessage;

--- a/src/interfaces/manual.ts
+++ b/src/interfaces/manual.ts
@@ -59,8 +59,10 @@ export function handlerSetup(
    *  potential payload.
    * @param {Object} [request] - an object containing request information. This
    *  is expected to be an object similar to the Node/Express request object.
-   * @param {String} [customMessage] - a string containing error message
-   *  information to override the builtin message given by an Error/Exception
+   * @param {String} [customMessage] - an optional error message string that
+   *  overrides the default message & stack trace. Message format must comply
+   *  with message field requirements defined in the documentation:
+   *  https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report#reportederrorevent
    * @param {Function} [callback] - a callback to be invoked once the message
    *  has been successfully submitted to the error reporting API or has failed
    *  after four attempts with the success or error response.

--- a/src/interfaces/manual.ts
+++ b/src/interfaces/manual.ts
@@ -55,11 +55,11 @@ export function handlerSetup(
    * application code.
    * @param {Any|ErrorMessage} err - error information of any type or content.
    *  This can be of any type but by giving an instance of ErrorMessage as the
-   *  error arugment one can manually provide values to all fields of the
+   *  error argument one can manually provide values to all fields of the
    *  potential payload.
    * @param {Object} [request] - an object containing request information. This
    *  is expected to be an object similar to the Node/Express request object.
-   * @param {String} [additionalMessage] - a string containing error message
+   * @param {String} [customMessage] - a string containing error message
    *  information to override the builtin message given by an Error/Exception
    * @param {Function} [callback] - a callback to be invoked once the message
    *  has been successfully submitted to the error reporting API or has failed
@@ -71,7 +71,7 @@ export function handlerSetup(
   function reportManualError(err: AnyError, request: Request): ErrorMessage;
   function reportManualError(
     err: AnyError,
-    additionalMessage: string
+    customMessage: string
   ): ErrorMessage;
   function reportManualError(err: AnyError, callback: Callback): ErrorMessage;
   function reportManualError(
@@ -82,41 +82,41 @@ export function handlerSetup(
   function reportManualError(
     err: AnyError,
     request: Request,
-    additionalMessage: string
+    customMessage: string
   ): ErrorMessage;
   function reportManualError(
     err: AnyError,
-    additionalMessage: string,
+    customMessage: string,
     callback: Callback
   ): ErrorMessage;
   function reportManualError(
     err: AnyError,
     request: Request,
-    additionalMessage: string,
+    customMessage: string,
     callback: Callback
   ): ErrorMessage;
   function reportManualError(
     err: AnyError,
     request?: Request | Callback | string,
-    additionalMessage?: Callback | string | {},
+    customMessage?: Callback | string,
     callback?: Callback | {} | string
   ): ErrorMessage {
     let em;
     if (is.string(request)) {
       // no request given
-      callback = additionalMessage;
-      additionalMessage = request;
+      callback = customMessage;
+      customMessage = request as string;
       request = undefined;
     } else if (is.function(request)) {
-      // neither request nor additionalMessage given
+      // neither request nor customMessage given
       callback = request;
       request = undefined;
-      additionalMessage = undefined;
+      customMessage = undefined;
     }
 
-    if (is.function(additionalMessage)) {
-      callback = additionalMessage;
-      additionalMessage = undefined;
+    if (is.function(customMessage)) {
+      callback = customMessage;
+      customMessage = undefined;
     }
 
     if (err instanceof ErrorMessage) {
@@ -157,8 +157,8 @@ export function handlerSetup(
       );
     }
 
-    if (is.string(additionalMessage)) {
-      em.setMessage(additionalMessage as string);
+    if (is.string(customMessage)) {
+      em.setMessage(customMessage as string);
     }
 
     // TODO: Address this type cast

--- a/test/unit/interfaces/manual.ts
+++ b/test/unit/interfaces/manual.ts
@@ -43,7 +43,7 @@ describe('Manual handler', () => {
     warn(message: string) {
       // The use of `report` in this class should issue the following
       // warning becasue the `report` class is used directly and, as such,
-      // cannot by itself have information where a ErrorMesasge was
+      // cannot by itself have information where a ErrorMessage was
       // constructed.  It only knows that an error has been reported. Thus,
       // the ErrorMessage objects given to the `report` method in the tests
       // do not have construction site information to verify that if that


### PR DESCRIPTION
Fixes #517  🦕

The original intent of additionalMessage was to let users manually override the entire [ReportedErrorEvent.message](https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report#reportederrorevent) field. Which according to specs, must include the error message & stack trace in the format: `errorMessage + "\n" + stacktrace`. Additionally error message must be a string.

PR changes: 
- renames `additionalMessage` param into `customMessage` param to be clearer about its intended use
- constrains `customMessage` param into only string, not object, type. As originally intended per original inline documentation: 
```
* @param {String} [additionalMessage] - a string containing error message
*  information to override the builtin message given by an Error/Exception
```

Tests passing.

**Breaking or nonbreaking**
I'm not sure whether to mark this PR as breaking or nonbreaking. Typically a change in an attr type warrants `breaking` but in this case, this attribute never worked, and is only introduced at the client lib layer...