### PR TITLE
test: patch broken @hapi/podium dependency

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,13 @@
   "compilerOptions": {
     "lib": ["es2018", "dom"],
     "rootDir": ".",
-    "outDir": "build"
+    "outDir": "build",
+    "baseUrl": ".",
+    "paths": {
+      "@hapi/podium": [
+        "node_modules/@types/hapi__podium"
+      ]
+    }
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
Fixes #549 🦕

Caused by hapi dependency incompatibility with new hapi/podium release (which came out in a patch but should have been minor) 

Tracking [origin issue](https://github.com/hapijs/hapi/issues/4240) here so we can eventually remove this patch in this repo. 
