### PR TITLE
fix: export ErrorMessage as part of the package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ import * as manualRequestExtractor from './request-extractors/manual';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RestifyRequestHandler = (req: any, res: any, next: Function) => any;
 
+export {ErrorMessage};
+
 /**
  * @typedef ConfigurationOptions
  * @type {Object}


### PR DESCRIPTION
Explicitly exports `ErrorMessage` class.

Fixes #584
