### PR TITLE
test: Coerce type to fix broken tests due to dependency change

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "console-log-level": "^1.4.1"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "1.1.20",
+    "@compodoc/compodoc": "1.1.22",
     "@hapi/hapi": "^21.0.0",
     "@types/boom": "^7.2.1",
     "@types/console-log-level": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "console-log-level": "^1.4.1"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "^1.1.10",
+    "@compodoc/compodoc": "1.1.14",
     "@hapi/hapi": "^21.0.0",
     "@types/boom": "^7.2.1",
     "@types/console-log-level": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "console-log-level": "^1.4.1"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "1.1.22",
+    "@compodoc/compodoc": "1.1.23",
     "@hapi/hapi": "^21.0.0",
     "@types/boom": "^7.2.1",
     "@types/console-log-level": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "console-log-level": "^1.4.1"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "1.1.23",
+    "@compodoc/compodoc": "1.1.23", // Some comment
     "@hapi/hapi": "^21.0.0",
     "@types/boom": "^7.2.1",
     "@types/console-log-level": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "console-log-level": "^1.4.1"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "1.1.14",
+    "@compodoc/compodoc": "1.1.20",
     "@hapi/hapi": "^21.0.0",
     "@types/boom": "^7.2.1",
     "@types/console-log-level": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "console-log-level": "^1.4.1"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "1.1.23", /* Some comment */
+    "@compodoc/compodoc": "1.1.23",
     "@hapi/hapi": "^21.0.0",
     "@types/boom": "^7.2.1",
     "@types/console-log-level": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "console-log-level": "^1.4.1"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "1.1.23", // Some comment
+    "@compodoc/compodoc": "1.1.23", /* Some comment */
     "@hapi/hapi": "^21.0.0",
     "@types/boom": "^7.2.1",
     "@types/console-log-level": "^1.4.0",

--- a/test/unit/interfaces/restify.ts
+++ b/test/unit/interfaces/restify.ts
@@ -25,7 +25,7 @@ import {handlerSetup as restifyInterface} from '../../../src/interfaces/restify'
 if (!EventEmitter.prototype.listenerCount) {
   EventEmitter.prototype.listenerCount = function (this, eventName) {
     // eslint-disable-next-line node/no-deprecated-api
-    return EventEmitter.listenerCount(this, eventName);
+    return EventEmitter.listenerCount(this, eventName as string);
   };
 }
 


### PR DESCRIPTION
This PR fixes tests that are broken due to changes in expected types. The added `as string` does not change the functionality of the tests, but it satisfies the compiler.

Also, one of the devDependencies is pinned because later versions don't work with earlier node versions. We might want to think about removing this dev dependency in the future.
