### PR TITLE
chore: remove api-logging team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/api-logging @googleapis/api-logging-partners
+*     @googleapis/yoshi-nodejs @googleapis/api-logging-partners
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/api-logging-partners
+*     @googleapis/yoshi-nodejs
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,2 +1,4 @@
-assign_issues: []
-assign_prs: []
+assign_issues:
+  - googleapis/yoshi-nodejs
+assign_prs:
+  - googleapis/yoshi-nodejs

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,4 +1,2 @@
-assign_issues:
-  - googleapis/api-logging-reviewers
-assign_prs:
-  - googleapis/api-logging-reviewers
+assign_issues: []
+assign_prs: []

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -22,5 +22,3 @@ permissionRules:
     permission: admin
   - team: jsteam
     permission: push
-  - team: api-logging-partners
-    permission: push    

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,7 +9,7 @@
   "repo": "googleapis/nodejs-error-reporting",
   "distribution_name": "@google-cloud/error-reporting",
   "api_id": "clouderrorreporting.googleapis.com",
-  "codeowner_team": "@googleapis/api-logging",
+  "codeowner_team": "@googleapis/api-logging-partners",
   "api_shortname": "error-reporting",
   "library_type": "REST"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,7 +9,7 @@
   "repo": "googleapis/nodejs-error-reporting",
   "distribution_name": "@google-cloud/error-reporting",
   "api_id": "clouderrorreporting.googleapis.com",
-  "codeowner_team": "@googleapis/api-logging-partners",
+  "codeowner_team": "@googleapis/yoshi-nodejs",
   "api_shortname": "error-reporting",
   "library_type": "REST"
 }


### PR DESCRIPTION
This PR removes the forbidden api-logging teams from configuration files and replaces them with the appropriate language team.

b/476446922